### PR TITLE
version extraction with awk

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,7 +33,7 @@ if ! command -v curl &> /dev/null; then
 fi
 
 if [ -z "$VERSION" ]; then
-	VERSION=$(curl -s "https://api.github.com/repos/configcat/cli/releases/latest" | grep -Po '"tag_name": "v\K.*?(?=")')
+    VERSION=$(curl -s "https://api.github.com/repos/configcat/cli/releases/latest" | awk '/tag_name/{gsub(/("v|"|",)/,"",$2);print $2}')
 fi
 
 DIR="${DIR:-/usr/local/bin}"


### PR DESCRIPTION
On macOS `grep -P` is not supported. 
`grep -P` has been replaced with an `awk` command.

I tested it on macOS 11.3.1.

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
