### PR TITLE
Update AliasCollector to allow detecting flags referenced as Ruby symbols

### DIFF
--- a/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
@@ -61,7 +61,7 @@ public class AliasCollector : IAliasCollector
                     if (line.Length > Constants.MaxCharCountPerLine || !flagKeys.Any(line.Contains))
                         return;
 
-                    var match = Regex.Match(line, @"[`{'""]?([a-zA-Z_$0-9]*)[[`}'\""]?\s*(?>\:?\s*(?>[sS]tring)?\s*=?>?\s*(?>new|await)?)\s*\S*[@$]?[`'""](" + keys + ")[`'\"]",
+                    var match = Regex.Match(line, @"[`{'""]?([a-zA-Z_$0-9]*)[[`}'\""]?\s*(?>\:?\s*(?>[sS]tring)?\s*=?>?\s*(?>new|await)?)\s*\S*[@$]?[`'"":](" + keys + ")[`'\"]?",
                         RegexOptions.Compiled);
 
                     while (match.Success && !cancellation.IsCancellationRequested)

--- a/test/ConfigCat.Cli.Tests/ScanTests.cs
+++ b/test/ConfigCat.Cli.Tests/ScanTests.cs
@@ -62,6 +62,7 @@ public class ScanTests
         Assert.Contains("PTestFlag", aliases);
 
         Assert.Contains("RTEST_FLAG", aliases);
+        Assert.Contains("RSTEST_FLAG", aliases);
 
         Assert.Contains("PHETestFlag", aliases);
         Assert.Contains("PHCTestFlag", aliases);

--- a/test/ConfigCat.Cli.Tests/alias.txt
+++ b/test/ConfigCat.Cli.Tests/alias.txt
@@ -76,6 +76,7 @@ class Flags(NoValue):
 
 class Flags
   RTEST_FLAG    = "test_flag"
+  RSTEST_FLAG   = :test_flag
 end
 
 


### PR DESCRIPTION
### Describe the purpose of your pull request

In ruby, scan currently detect a flag used as a string: `client_wrapper.get_flag('my_flag')`
These changes would allow detecting the same flag used as a symbol: `client_wrapper.get_flag(:my_flag)`

I am proposing these changes mostly to make it easier to migrate from our previous feature flag solution (which accepts flag names as Ruby symbols as well as strings) to ConfigCat. Although I don't know how safe they will be for everyone since this makes the last bit of the regex optional...

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [X] I have covered the applied changes with automated tests.
- [X] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [X] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
