### PR TITLE
Webhook / Product preferences / Invitations commands, custom scan alias patterns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,10 @@ This is the complete list of the available commands provided by the CLI.
 | [configcat product create](configcat-product-create.md) | Create a new Product in a specified Organization identified by the `--organization-id` option |
 | [configcat product rm](configcat-product-rm.md) | Remove a Product identified by the `--product-id` option |
 | [configcat product update](configcat-product-update.md) | Update a Product identified by the `--product-id` option |
+| [configcat product preferences](configcat-product-preferences.md) | Manage Product preferences |
+| [configcat product preferences show](configcat-product-preferences-show.md) | Show a Product's preferences |
+| [configcat product preferences update](configcat-product-preferences-update.md) | Update a Product's preferences |
+| [configcat product preferences update env](configcat-product-preferences-update-env.md) | Update per-environment required reason |
 ### configcat config
 | Command | Description |
 | ------ | ----------- |
@@ -35,6 +39,18 @@ This is the complete list of the available commands provided by the CLI.
 | [configcat config create](configcat-config-create.md) | Create a new Config in a specified Product identified by the `--product-id` option |
 | [configcat config rm](configcat-config-rm.md) | Remove a Config identified by the `--config-id` option |
 | [configcat config update](configcat-config-update.md) | Update a Config identified by the `--config-id` option |
+### configcat webhook
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook](configcat-webhook.md) | Manage Webhooks |
+| [configcat webhook ls](configcat-webhook-ls.md) | List all Webhooks that belongs to the configured user |
+| [configcat webhook show](configcat-webhook-show.md) | Print a Webhook identified by the `--webhook-id` option |
+| [configcat webhook create](configcat-webhook-create.md) | Create a new Webhook |
+| [configcat webhook rm](configcat-webhook-rm.md) | Remove a Webhook identified by the `--webhook-id` option |
+| [configcat webhook update](configcat-webhook-update.md) | Update a Webhook identified by the `--webhook-id` option |
+| [configcat webhook headers](configcat-webhook-headers.md) | Manage Webhook headers |
+| [configcat webhook headers add](configcat-webhook-headers-add.md) | Add new header |
+| [configcat webhook headers rm](configcat-webhook-headers-rm.md) | Remove header |
 ### configcat environment
 | Command | Description |
 | ------ | ----------- |
@@ -119,6 +135,8 @@ This is the complete list of the available commands provided by the CLI.
 | Command | Description |
 | ------ | ----------- |
 | [configcat member](configcat-member.md) | Manage Members |
+| [configcat member lsio](configcat-member-lsio.md) | List all pending Invitations that belongs to an Organization |
+| [configcat member lsip](configcat-member-lsip.md) | List all pending Invitations that belongs to a Product |
 | [configcat member lso](configcat-member-lso.md) | List all Members that belongs to an Organization |
 | [configcat member lsp](configcat-member-lsp.md) | List all Members that belongs to a Product |
 | [configcat member rm](configcat-member-rm.md) | Remove Member from an Organization |

--- a/docs/configcat-member-lsio.md
+++ b/docs/configcat-member-lsio.md
@@ -1,0 +1,22 @@
+# configcat member lsio
+List all pending Invitations that belongs to an Organization
+## Usage
+```
+configcat member lsio [options]
+```
+## Example
+```
+configcat member lsio -o <organization-id>
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--organization-id`, `-o` | Show only an Organization's Members |
+| `--json` | Format the output in JSON |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat member](configcat-member.md) | Manage Members |

--- a/docs/configcat-member-lsip.md
+++ b/docs/configcat-member-lsip.md
@@ -1,0 +1,22 @@
+# configcat member lsip
+List all pending Invitations that belongs to a Product
+## Usage
+```
+configcat member lsip [options]
+```
+## Example
+```
+configcat member lsip -p <product-id>
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--product-id`, `-p` | Show only a Product's Members |
+| `--json` | Format the output in JSON |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat member](configcat-member.md) | Manage Members |

--- a/docs/configcat-member.md
+++ b/docs/configcat-member.md
@@ -19,6 +19,8 @@ configcat member [command]
 ## Subcommands
 | Command | Description |
 | ------ | ----------- |
+| [configcat member lsio](configcat-member-lsio.md) | List all pending Invitations that belongs to an Organization |
+| [configcat member lsip](configcat-member-lsip.md) | List all pending Invitations that belongs to a Product |
 | [configcat member lso](configcat-member-lso.md) | List all Members that belongs to an Organization |
 | [configcat member lsp](configcat-member-lsp.md) | List all Members that belongs to a Product |
 | [configcat member rm](configcat-member-rm.md) | Remove Member from an Organization |

--- a/docs/configcat-product-preferences-show.md
+++ b/docs/configcat-product-preferences-show.md
@@ -1,0 +1,24 @@
+# configcat product preferences show
+Show a Product's preferences
+## Aliases
+`sh`, `print`
+## Usage
+```
+configcat product preferences show [options]
+```
+## Example
+```
+configcat product preferences show -i <product-id>
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--product-id`, `-i` | ID of the Product |
+| `--json` | Format the output in JSON |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat product preferences](configcat-product-preferences.md) | Manage Product preferences |

--- a/docs/configcat-product-preferences-update-env.md
+++ b/docs/configcat-product-preferences-update-env.md
@@ -1,0 +1,24 @@
+# configcat product preferences update env
+Update per-environment required reason
+## Aliases
+`e`
+## Usage
+```
+configcat product preferences update env [options]
+```
+## Example
+```
+configcat product preferences update env -i <product-id> -ei <environment-id>:true
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--product-id`, `-i` | ID of the Product |
+| `--environments`, `-ei` | Format: `<environment-id>:<reason-required>`. |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat product preferences update](configcat-product-preferences-update.md) | Update a Product's preferences |

--- a/docs/configcat-product-preferences-update.md
+++ b/docs/configcat-product-preferences-update.md
@@ -1,0 +1,31 @@
+# configcat product preferences update
+Update a Product's preferences
+## Aliases
+`up`
+## Usage
+```
+configcat product preferences update [command] [options]
+```
+## Example
+```
+configcat product preferences update -i <product-id> --reason-required true
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--product-id`, `-i` | ID of the Product |
+| `--reason-required`, `-rr` | Indicates that a mandatory note is required for saving and publishing |
+| `--key-gen-mode`, `-kg` | Determines the Feature Flag key generation mode<br/><br/>*Possible values*: `camelCase`, `kebabCase`, `lowerCase`, `pascalCase`, `upperCase` |
+| `--show-variation-id`, `-vi` | Indicates whether a variation ID's must be shown on the ConfigCat Dashboard |
+| `--mandatory-setting-hint`, `-msh` | Indicates whether Feature flags and Settings must have a hint |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat product preferences](configcat-product-preferences.md) | Manage Product preferences |
+## Subcommands
+| Command | Description |
+| ------ | ----------- |
+| [configcat product preferences update env](configcat-product-preferences-update-env.md) | Update per-environment required reason |

--- a/docs/configcat-product-preferences.md
+++ b/docs/configcat-product-preferences.md
@@ -1,0 +1,23 @@
+# configcat product preferences
+Manage Product preferences
+## Aliases
+`pr`
+## Usage
+```
+configcat product preferences [command]
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat product](configcat-product.md) | Manage Products |
+## Subcommands
+| Command | Description |
+| ------ | ----------- |
+| [configcat product preferences show](configcat-product-preferences-show.md) | Show a Product's preferences |
+| [configcat product preferences update](configcat-product-preferences-update.md) | Update a Product's preferences |

--- a/docs/configcat-product.md
+++ b/docs/configcat-product.md
@@ -23,3 +23,4 @@ configcat product [command]
 | [configcat product create](configcat-product-create.md) | Create a new Product in a specified Organization identified by the `--organization-id` option |
 | [configcat product rm](configcat-product-rm.md) | Remove a Product identified by the `--product-id` option |
 | [configcat product update](configcat-product-update.md) | Update a Product identified by the `--product-id` option |
+| [configcat product preferences](configcat-product-preferences.md) | Manage Product preferences |

--- a/docs/configcat-scan.md
+++ b/docs/configcat-scan.md
@@ -22,6 +22,7 @@ configcat scan ./dir -c <config-id> -l 5 --print
 | `--commit-url-template`, `-ct` | Template url used to generate VCS commit links. Available template parameters: `commitHash`. Example: https://github.com/my/repo/commit/{commitHash} |
 | `--runner`, `-ru` | Overrides the default `ConfigCat CLI {version}` executor label on the ConfigCat dashboard |
 | `--exclude-flag-keys`, `-ex` | Exclude the given Feature Flag keys from scanning. E.g.: `-ex flag1 flag2` or `-ex 'flag1,flag2'` |
+| `--alias-patterns`, `-ap` | List of custom regex patterns used to search for additional aliases |
 | `--verbose`, `-v`, `/v` | Print detailed execution information |
 | `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
 | `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |

--- a/docs/configcat-webhook-create.md
+++ b/docs/configcat-webhook-create.md
@@ -1,0 +1,27 @@
+# configcat webhook create
+Create a new Webhook
+## Aliases
+`cr`
+## Usage
+```
+configcat webhook create [options]
+```
+## Example
+```
+configcat webhook create -c <config-id> -e <environment-id> -u "https://example.com/hook" -m get
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--config-id`, `-c` | ID of the Config |
+| `--environment-id`, `-e` | ID of the Environment |
+| `--url`, `-u` | The Webhook's URL |
+| `--http-method`, `-m` | The Webhook's HTTP method<br/><br/>*Possible values*: `get`, `post` |
+| `--content`, `-co` | The Webhook's HTTP body |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook](configcat-webhook.md) | Manage Webhooks |

--- a/docs/configcat-webhook-headers-add.md
+++ b/docs/configcat-webhook-headers-add.md
@@ -1,0 +1,26 @@
+# configcat webhook headers add
+Add new header
+## Aliases
+`a`
+## Usage
+```
+configcat webhook headers add [options]
+```
+## Example
+```
+configcat webhook headers add -i <webhook-id> -k Authorization -val "Bearer ..." --secure
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--webhook-id`, `-i` | ID of the Webhook to update |
+| `--key`, `-k` | The Webhook header's key |
+| `--value`, `-val` | The Webhook header's value |
+| `--secure`, `-s` | If it's true, the Webhook header's value will kept as a secret |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook headers](configcat-webhook-headers.md) | Manage Webhook headers |

--- a/docs/configcat-webhook-headers-rm.md
+++ b/docs/configcat-webhook-headers-rm.md
@@ -1,0 +1,22 @@
+# configcat webhook headers rm
+Remove header
+## Usage
+```
+configcat webhook headers rm [options]
+```
+## Example
+```
+configcat webhook headers rm -i <webhook-id> -k Authorization
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--webhook-id`, `-i` | ID of the Webhook to update |
+| `--key`, `-k` | The Webhook header's key |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook headers](configcat-webhook-headers.md) | Manage Webhook headers |

--- a/docs/configcat-webhook-headers.md
+++ b/docs/configcat-webhook-headers.md
@@ -1,0 +1,23 @@
+# configcat webhook headers
+Manage Webhook headers
+## Aliases
+`he`
+## Usage
+```
+configcat webhook headers [command]
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook](configcat-webhook.md) | Manage Webhooks |
+## Subcommands
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook headers add](configcat-webhook-headers-add.md) | Add new header |
+| [configcat webhook headers rm](configcat-webhook-headers-rm.md) | Remove header |

--- a/docs/configcat-webhook-ls.md
+++ b/docs/configcat-webhook-ls.md
@@ -1,0 +1,22 @@
+# configcat webhook ls
+List all Webhooks that belongs to the configured user
+## Usage
+```
+configcat webhook ls [options]
+```
+## Example
+```
+configcat webhook ls
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--product-id`, `-p` | Show only a Product's Webhooks |
+| `--json` | Format the output in JSON |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook](configcat-webhook.md) | Manage Webhooks |

--- a/docs/configcat-webhook-rm.md
+++ b/docs/configcat-webhook-rm.md
@@ -1,0 +1,21 @@
+# configcat webhook rm
+Remove a Webhook identified by the `--webhook-id` option
+## Usage
+```
+configcat webhook rm [options]
+```
+## Example
+```
+configcat webhook rm -i <webhook-id>
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--webhook-id`, `-i` | ID of the Webhook to delete |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook](configcat-webhook.md) | Manage Webhooks |

--- a/docs/configcat-webhook-show.md
+++ b/docs/configcat-webhook-show.md
@@ -1,0 +1,23 @@
+# configcat webhook show
+Print a Webhook identified by the `--webhook-id` option
+## Aliases
+`sh`, `print`
+## Usage
+```
+configcat webhook show [options]
+```
+## Example
+```
+configcat webhook sh -i <webhook-id>
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--webhook-id`, `-i` | ID of the Webhook |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook](configcat-webhook.md) | Manage Webhooks |

--- a/docs/configcat-webhook-update.md
+++ b/docs/configcat-webhook-update.md
@@ -1,0 +1,26 @@
+# configcat webhook update
+Update a Webhook identified by the `--webhook-id` option
+## Aliases
+`up`
+## Usage
+```
+configcat webhook update [options]
+```
+## Example
+```
+configcat webhook update -i <webhook-id> -u "https://example.com/hook" -m get
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--webhook-id`, `-i` | ID of the Webhook to update |
+| `--url`, `-u` | The Webhook's URL |
+| `--http-method`, `-m` | The Webhook's HTTP method<br/><br/>*Possible values*: `get`, `post` |
+| `--content`, `-co` | The Webhook's HTTP body |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook](configcat-webhook.md) | Manage Webhooks |

--- a/docs/configcat-webhook.md
+++ b/docs/configcat-webhook.md
@@ -1,0 +1,27 @@
+# configcat webhook
+Manage Webhooks
+## Aliases
+`wh`
+## Usage
+```
+configcat webhook [command]
+```
+## Options
+| Option | Description |
+| ------ | ----------- |
+| `--verbose`, `-v`, `/v` | Print detailed execution information |
+| `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
+| `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |
+## Parent Command
+| Command | Description |
+| ------ | ----------- |
+| [configcat](index.md) | This is the Command Line Tool of ConfigCat.<br/>ConfigCat is a hosted feature flag service: https://configcat.com<br/>For more information, see the documentation here: https://configcat.com/docs/advanced/cli |
+## Subcommands
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook ls](configcat-webhook-ls.md) | List all Webhooks that belongs to the configured user |
+| [configcat webhook show](configcat-webhook-show.md) | Print a Webhook identified by the `--webhook-id` option |
+| [configcat webhook create](configcat-webhook-create.md) | Create a new Webhook |
+| [configcat webhook rm](configcat-webhook-rm.md) | Remove a Webhook identified by the `--webhook-id` option |
+| [configcat webhook update](configcat-webhook-update.md) | Update a Webhook identified by the `--webhook-id` option |
+| [configcat webhook headers](configcat-webhook-headers.md) | Manage Webhook headers |

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,10 @@ This is the complete list of the available commands provided by the CLI.
 | [configcat product create](configcat-product-create.md) | Create a new Product in a specified Organization identified by the `--organization-id` option |
 | [configcat product rm](configcat-product-rm.md) | Remove a Product identified by the `--product-id` option |
 | [configcat product update](configcat-product-update.md) | Update a Product identified by the `--product-id` option |
+| [configcat product preferences](configcat-product-preferences.md) | Manage Product preferences |
+| [configcat product preferences show](configcat-product-preferences-show.md) | Show a Product's preferences |
+| [configcat product preferences update](configcat-product-preferences-update.md) | Update a Product's preferences |
+| [configcat product preferences update env](configcat-product-preferences-update-env.md) | Update per-environment required reason |
 ### configcat config
 | Command | Description |
 | ------ | ----------- |
@@ -35,6 +39,18 @@ This is the complete list of the available commands provided by the CLI.
 | [configcat config create](configcat-config-create.md) | Create a new Config in a specified Product identified by the `--product-id` option |
 | [configcat config rm](configcat-config-rm.md) | Remove a Config identified by the `--config-id` option |
 | [configcat config update](configcat-config-update.md) | Update a Config identified by the `--config-id` option |
+### configcat webhook
+| Command | Description |
+| ------ | ----------- |
+| [configcat webhook](configcat-webhook.md) | Manage Webhooks |
+| [configcat webhook ls](configcat-webhook-ls.md) | List all Webhooks that belongs to the configured user |
+| [configcat webhook show](configcat-webhook-show.md) | Print a Webhook identified by the `--webhook-id` option |
+| [configcat webhook create](configcat-webhook-create.md) | Create a new Webhook |
+| [configcat webhook rm](configcat-webhook-rm.md) | Remove a Webhook identified by the `--webhook-id` option |
+| [configcat webhook update](configcat-webhook-update.md) | Update a Webhook identified by the `--webhook-id` option |
+| [configcat webhook headers](configcat-webhook-headers.md) | Manage Webhook headers |
+| [configcat webhook headers add](configcat-webhook-headers-add.md) | Add new header |
+| [configcat webhook headers rm](configcat-webhook-headers-rm.md) | Remove header |
 ### configcat environment
 | Command | Description |
 | ------ | ----------- |
@@ -119,6 +135,8 @@ This is the complete list of the available commands provided by the CLI.
 | Command | Description |
 | ------ | ----------- |
 | [configcat member](configcat-member.md) | Manage Members |
+| [configcat member lsio](configcat-member-lsio.md) | List all pending Invitations that belongs to an Organization |
+| [configcat member lsip](configcat-member-lsip.md) | List all pending Invitations that belongs to a Product |
 | [configcat member lso](configcat-member-lso.md) | List all Members that belongs to an Organization |
 | [configcat member lsp](configcat-member-lsp.md) | List all Members that belongs to a Product |
 | [configcat member rm](configcat-member-rm.md) | Remove Member from an Organization |

--- a/src/ConfigCat.Cli.Models/Api/MemberModel.cs
+++ b/src/ConfigCat.Cli.Models/Api/MemberModel.cs
@@ -1,8 +1,12 @@
+using System;
+
 namespace ConfigCat.Cli.Models.Api;
 
 public class OrganizationMembersModel
 {
     public MemberModel[] Admins { get; set; }  
+    
+    public MemberModel[] BillingManagers { get; set; }  
     
     public OrganizationMemberModel[] Members { get; set; }  
 }
@@ -26,6 +30,8 @@ public class MemberModel
     public string Email { get; set; }
 
     public string FullName { get; set; }
+
+    public bool TwoFactorEnabled { get; set; }
 }
 
 public class ProductMemberModel : MemberModel
@@ -43,4 +49,17 @@ public class InviteMemberModel
 public class UpdateMembersModel
 {
     public long[] PermissionGroupIds { get; set; }
+}
+
+public class InvitationModel
+{
+    public string InvitationId { get; set; }
+
+    public string Email { get; set; }
+
+    public int PermissionGroupId { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public bool Expired { get; set; }
 }

--- a/src/ConfigCat.Cli.Models/Api/ProductModel.cs
+++ b/src/ConfigCat.Cli.Models/Api/ProductModel.cs
@@ -1,4 +1,6 @@
-﻿namespace ConfigCat.Cli.Models.Api;
+﻿using System.Collections.Generic;
+
+namespace ConfigCat.Cli.Models.Api;
 
 public class ProductModel
 {
@@ -11,4 +13,26 @@ public class ProductModel
     public string Description { get; set; }
 
     public int Order { get; set; }
+}
+
+public class ProductPreferencesModel
+{
+    public bool ReasonRequired { get; set; }
+
+    public string KeyGenerationMode { get; set; }
+
+    public bool ShowVariationId { get; set; }
+
+    public bool MandatorySettingHint { get; set; }
+
+    public IEnumerable<ReasonRequiredEnvironmentModel> ReasonRequiredEnvironments { get; set; }
+}
+
+public class ReasonRequiredEnvironmentModel
+{
+    public string EnvironmentId { get; set; }
+
+    public bool ReasonRequired { get; set; }
+
+    public string EnvironmentName { get; set; }
 }

--- a/src/ConfigCat.Cli.Models/Api/WebhookModel.cs
+++ b/src/ConfigCat.Cli.Models/Api/WebhookModel.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ConfigCat.Cli.Models.Api;
+
+public class WebhookModel
+{
+    public int WebhookId { get; set; }
+
+    public string Url { get; set; }
+
+    public string HttpMethod { get; set; }
+
+    public string Content { get; set; }
+
+    public ConfigModel Config { get; set; }
+
+    public EnvironmentModel Environment { get; set; }
+
+    [JsonPropertyName("webHookHeaders")]
+    public IEnumerable<WebhookHeaderModel> WebhookHeaders { get; set; }
+
+    public UpdateWebhookModel ToUpdateModel() => new()
+    {
+        Url = this.Url,
+        HttpMethod = this.HttpMethod,
+        Content = this.Content,
+    };
+}
+
+public class WebhookHeaderModel
+{
+    public string Key { get; set; }
+
+    public string Value { get; set; }
+
+    public bool IsSecure { get; set; }
+}
+
+public class UpdateWebhookModel
+{
+    public string Url { get; set; }
+
+    public string HttpMethod { get; set; }
+
+    public string Content { get; set; }
+}

--- a/src/ConfigCat.Cli.Services/Api/MemberClient.cs
+++ b/src/ConfigCat.Cli.Services/Api/MemberClient.cs
@@ -11,6 +11,10 @@ namespace ConfigCat.Cli.Services.Api;
 
 public interface IMemberClient
 {
+    Task<IEnumerable<InvitationModel>> GetOrganizationInvitationsAsync(string organizationId, CancellationToken token);
+    
+    Task<IEnumerable<InvitationModel>> GetProductInvitationsAsync(string productId, CancellationToken token);
+    
     Task<OrganizationMembersModel> GetOrganizationMembersAsync(string organizationId, CancellationToken token);
 
     Task<IEnumerable<ProductMemberModel>> GetProductMembersAsync(string productId, CancellationToken token);
@@ -31,6 +35,12 @@ public class MemberClient(
     HttpClient httpClient)
     : ApiClient(output, config, botPolicy, httpClient), IMemberClient
 {
+    public Task<IEnumerable<InvitationModel>> GetOrganizationInvitationsAsync(string organizationId, CancellationToken token) =>
+        this.GetAsync<IEnumerable<InvitationModel>>(HttpMethod.Get, $"v1/organizations/{organizationId}/invitations", token);
+
+    public Task<IEnumerable<InvitationModel>> GetProductInvitationsAsync(string productId, CancellationToken token) =>
+        this.GetAsync<IEnumerable<InvitationModel>>(HttpMethod.Get, $"v1/products/{productId}/invitations", token);
+
     public Task<OrganizationMembersModel> GetOrganizationMembersAsync(string organizationId, CancellationToken token) =>
         this.GetAsync<OrganizationMembersModel>(HttpMethod.Get, $"v2/organizations/{organizationId}/members", token);
 

--- a/src/ConfigCat.Cli.Services/Api/ProductClient.cs
+++ b/src/ConfigCat.Cli.Services/Api/ProductClient.cs
@@ -14,10 +14,14 @@ public interface IProductClient
     Task<IEnumerable<ProductModel>> GetProductsAsync(CancellationToken token);
 
     Task<ProductModel> GetProductAsync(string productId, CancellationToken token);
+    
+    Task<ProductPreferencesModel> GetProductPreferencesAsync(string productId, CancellationToken token);
 
     Task<ProductModel> CreateProductAsync(string organizationId, string name, string description, CancellationToken token);
 
     Task UpdateProductAsync(string productId, string name, string description, CancellationToken token);
+    
+    Task UpdateProductPreferencesAsync(string productId, ProductPreferencesModel model, CancellationToken token);
 
     Task DeleteProductAsync(string productId, CancellationToken token);
 }
@@ -35,8 +39,19 @@ public class ProductClient(
     public Task<ProductModel> GetProductAsync(string productId, CancellationToken token) =>
         this.GetAsync<ProductModel>(HttpMethod.Get, $"v1/products/{productId}", token);
 
+    public Task<ProductPreferencesModel> GetProductPreferencesAsync(string productId, CancellationToken token) =>
+        this.GetAsync<ProductPreferencesModel>(HttpMethod.Get, $"v1/products/{productId}/preferences", token);
+
     public Task<ProductModel> CreateProductAsync(string organizationId, string name, string description, CancellationToken token) =>
         this.SendAsync<ProductModel>(HttpMethod.Post, $"v1/organizations/{organizationId}/products", new { Name = name, Description = description }, token);
+
+    public async Task UpdateProductPreferencesAsync(string productId, ProductPreferencesModel model, CancellationToken token)
+    {
+        this.Output.Write($"Updating Product preferences... ");
+        await this.SendAsync(HttpMethod.Post, $"v1/products/{productId}/preferences", model, token);
+        this.Output.WriteSuccess();
+        this.Output.WriteLine();
+    }
 
     public async Task DeleteProductAsync(string productId, CancellationToken token)
     {

--- a/src/ConfigCat.Cli.Services/Api/WebhookClient.cs
+++ b/src/ConfigCat.Cli.Services/Api/WebhookClient.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ConfigCat.Cli.Models.Api;
+using ConfigCat.Cli.Models.Configuration;
+using ConfigCat.Cli.Services.Json;
+using ConfigCat.Cli.Services.Rendering;
+using Trybot;
+
+namespace ConfigCat.Cli.Services.Api;
+
+public interface IWebhookClient
+{
+    Task<IEnumerable<WebhookModel>> GetWebhooksAsync(string productId, CancellationToken token);
+
+    Task<WebhookModel> CreateWebhookAsync(string configId, string environmentId, string url, string httpMethod, string content, CancellationToken token);
+
+    Task<WebhookModel> GetWebhookAsync(int webhookId, CancellationToken token);
+
+    Task UpdateWebhookAsync(int webhookId, List<JsonPatchOperation> operations, CancellationToken token);
+
+    Task DeleteWebhookAsync(int webhookId, CancellationToken token);
+}
+
+public class WebhookClient(
+    IOutput output,
+    CliConfig config,
+    IBotPolicy<HttpResponseMessage> botPolicy,
+    HttpClient httpClient)
+    : ApiClient(output, config, botPolicy, httpClient), IWebhookClient
+{
+    public Task<IEnumerable<WebhookModel>> GetWebhooksAsync(string productId, CancellationToken token) =>
+        this.GetAsync<IEnumerable<WebhookModel>>(HttpMethod.Get, $"v1/products/{productId}/webhooks", token);
+
+    public Task<WebhookModel> GetWebhookAsync(int webhookId, CancellationToken token) =>
+        this.GetAsync<WebhookModel>(HttpMethod.Get, $"v1/webhooks/{webhookId}", token);
+
+    public Task<WebhookModel> CreateWebhookAsync(string configId, string environmentId, string url, string httpMethod,
+        string content, CancellationToken token) =>
+        this.SendAsync<WebhookModel>(HttpMethod.Post, $"v1/configs/{configId}/environments/{environmentId}/webhooks",
+            new { Url = url, HttpMethod = httpMethod, Content = content }, token);
+    
+    public async Task UpdateWebhookAsync(int webhookId, List<JsonPatchOperation> operations, CancellationToken token)
+    {
+        this.Output.Write($"Updating Webhook... ");
+        await this.SendAsync(HttpMethod.Patch, $"v1/webhooks/{webhookId}", operations, token);
+        this.Output.WriteSuccess();
+        this.Output.WriteLine();
+    }
+
+    public async Task DeleteWebhookAsync(int webhookId, CancellationToken token)
+    {
+        this.Output.Write($"Deleting Webhook... ");
+        await this.SendAsync(HttpMethod.Delete, $"v1/webhooks/{webhookId}", null, token);
+        this.Output.WriteSuccess();
+        this.Output.WriteLine();
+    }
+}

--- a/src/ConfigCat.Cli.Services/Constants.cs
+++ b/src/ConfigCat.Cli.Services/Constants.cs
@@ -11,6 +11,7 @@ public static class Constants
     public const string ApiHostEnvironmentVariableName = "CONFIGCAT_API_HOST";
     public const string ApiUserNameEnvironmentVariableName = "CONFIGCAT_API_USER";
     public const string ApiPasswordEnvironmentVariableName = "CONFIGCAT_API_PASS";
+    public const string AliasPatternsEnvironmentVariableName = "CONFIGCAT_ALIAS_PATTERNS";
 
     public static readonly string ConfigFilePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
@@ -173,4 +174,34 @@ public static class SettingTypes
     public const string String = "string";
     public const string Int = "int";
     public const string Double = "double";
+}
+
+public static class KeyGenerationModes
+{
+    public static readonly string[] Collection =
+    [
+        CamelCase,
+        LowerCase,
+        UpperCase,
+        PascalCase,
+        KebabCase
+    ];
+
+    public const string CamelCase = "camelCase";
+    public const string LowerCase = "lowerCase";
+    public const string UpperCase = "upperCase";
+    public const string PascalCase = "pascalCase";
+    public const string KebabCase = "kebabCase";
+}
+
+public static class HttpMethods
+{
+    public static readonly string[] Collection =
+    [
+        Get,
+        Post,
+    ];
+
+    public const string Get = "get";
+    public const string Post = "post";
 }

--- a/src/ConfigCat.Cli.Services/Extensions/SystemExtensions.cs
+++ b/src/ConfigCat.Cli.Services/Extensions/SystemExtensions.cs
@@ -136,4 +136,10 @@ public static class SystemExtensions
                 "numberGreaterOrEquals" => true,
             _ => false
         };
+    
+    public static string TrimToFitColumn(this string text)
+        => text == null ? "\"\"" : $"\"{text.TrimToLength(30)}\"";
+    
+    public static string TrimToLength(this string text, int length)
+        => text.Length > length ? $"{text[0..(length - 2)]}..." : text;
 }

--- a/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
@@ -10,14 +10,13 @@ using System;
 using System.Text.RegularExpressions;
 using System.Linq;
 using ConfigCat.Cli.Models.Scan;
-using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 
 namespace ConfigCat.Cli.Services.Scan;
 
 public interface IAliasCollector
 {
-    Task<AliasScanResult> CollectAsync(IEnumerable<FlagModel> flags,
+    Task<AliasScanResult> CollectAsync(FlagModel[] flags,
         FileInfo fileToScan,
         string[] matchPatterns,
         CancellationToken token);
@@ -37,7 +36,7 @@ public class AliasCollector : IAliasCollector
         this.botPolicy.Configure(p => p.Timeout(t => t.After(TimeSpan.FromSeconds(10))));
     }
 
-    public async Task<AliasScanResult> CollectAsync(IEnumerable<FlagModel> flags, FileInfo fileToScan,
+    public async Task<AliasScanResult> CollectAsync(FlagModel[] flags, FileInfo fileToScan,
         string[] matchPatterns, CancellationToken token)
     {
         try
@@ -85,6 +84,9 @@ public class AliasCollector : IAliasCollector
                     {
                         foreach (var matchPattern in matchPatterns)
                         {
+                            if (!matchPattern.Contains("CC_KEY"))
+                                continue;
+                            
                             var regMatch = Regex.Match(line, matchPattern.Replace("CC_KEY", $"[`'\"]?({keys})[`'\"]?"), RegexOptions.Compiled);
                             while (regMatch.Success && !cancellation.IsCancellationRequested)
                             {

--- a/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
@@ -97,7 +97,7 @@ public class AliasCollector : IAliasCollector
                                 if (flag != null)
                                     result.FoundFlags.Add(flag);
 
-                                if (flag != null && !found.IsEmpty() && Similarity(flag.Key, found) > 0.3)
+                                if (flag != null && !found.IsEmpty())
                                     result.FlagAliases.AddOrUpdate(flag, [found], (k, v) => { v.Add(found); return v; });
 
                                 regMatch = regMatch.NextMatch();

--- a/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
+++ b/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
@@ -15,6 +15,7 @@ public interface IFileScanner
 {
     Task<IEnumerable<FlagReferenceResult>> ScanAsync(IEnumerable<FlagModel> flags,
         IEnumerable<FileInfo> filesToScan,
+        string[] matchPatterns,
         int contextLines,
         CancellationToken token);
 }
@@ -40,16 +41,16 @@ public class FileScanner : IFileScanner
 
     public async Task<IEnumerable<FlagReferenceResult>> ScanAsync(IEnumerable<FlagModel> flags,
         IEnumerable<FileInfo> filesToScan,
+        string[] matchPatterns,
         int contextLines,
         CancellationToken token)
     {
         using var spinner = this.output.CreateSpinner(token);
-
         return await this.botPolicy.ExecuteAsync(async (ctx, cancellation) =>
         {
             this.output.Verbose($"Searching for flag ALIASES...", ConsoleColor.Magenta);
             var aliasTasks = filesToScan.TakeWhile(file => !cancellation.IsCancellationRequested)
-                .Select(file => this.aliasCollector.CollectAsync(flags, file, token));
+                .Select(file => this.aliasCollector.CollectAsync(flags, file, matchPatterns, token));
 
             var aliasResults = (await Task.WhenAll(aliasTasks)).Where(r => r is not null).ToArray();
 

--- a/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
+++ b/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
@@ -13,8 +13,8 @@ namespace ConfigCat.Cli.Services.Scan;
 
 public interface IFileScanner
 {
-    Task<IEnumerable<FlagReferenceResult>> ScanAsync(IEnumerable<FlagModel> flags,
-        IEnumerable<FileInfo> filesToScan,
+    Task<IEnumerable<FlagReferenceResult>> ScanAsync(FlagModel[] flags,
+        FileInfo[] filesToScan,
         string[] matchPatterns,
         int contextLines,
         CancellationToken token);
@@ -39,8 +39,8 @@ public class FileScanner : IFileScanner
         this.botPolicy.Configure(p => p.Timeout(t => t.After(TimeSpan.FromSeconds(600))));
     }
 
-    public async Task<IEnumerable<FlagReferenceResult>> ScanAsync(IEnumerable<FlagModel> flags,
-        IEnumerable<FileInfo> filesToScan,
+    public async Task<IEnumerable<FlagReferenceResult>> ScanAsync(FlagModel[] flags,
+        FileInfo[] filesToScan,
         string[] matchPatterns,
         int contextLines,
         CancellationToken token)

--- a/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
+++ b/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
@@ -49,6 +49,8 @@ public class FileScanner : IFileScanner
         return await this.botPolicy.ExecuteAsync(async (ctx, cancellation) =>
         {
             this.output.Verbose($"Searching for flag ALIASES...", ConsoleColor.Magenta);
+            if (matchPatterns.Length > 0)
+                this.output.Verbose($"Using the following custom alias patterns: {string.Join(", ", matchPatterns.Select(p => $"'{p}'"))}");
             var aliasTasks = filesToScan.TakeWhile(file => !cancellation.IsCancellationRequested)
                 .Select(file => this.aliasCollector.CollectAsync(flags, file, matchPatterns, token));
 

--- a/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
+++ b/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
@@ -55,7 +55,11 @@ public class FileScanner : IFileScanner
             var aliasResults = (await Task.WhenAll(aliasTasks)).Where(r => r is not null).ToArray();
 
             foreach (var (key, value) in aliasResults.SelectMany(a => a.FlagAliases))
-                key.Aliases = value.Distinct().ToList();
+            {
+                key.Aliases ??= [];
+                key.Aliases.AddRange(value);
+                key.Aliases = key.Aliases.Distinct().ToList();
+            }
 
             var foundFlags = aliasResults.SelectMany(a => a.FoundFlags).Distinct().ToArray();
 

--- a/src/ConfigCat.Cli/Commands/Flags/FlagTargeting.cs
+++ b/src/ConfigCat.Cli/Commands/Flags/FlagTargeting.cs
@@ -55,6 +55,9 @@ internal class FlagTargeting(
         if (!addTargetingRuleModel.FlagValue.TryParseFlagValue(flag.SettingType, out var parsed))
             throw new ShowHelpException($"Flag value '{addTargetingRuleModel.FlagValue}' must respect the type '{flag.SettingType}'.");
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Add($"/{FlagValueModel.TargetingRuleJsonName}/-", new TargetingModel
         {
@@ -108,6 +111,9 @@ internal class FlagTargeting(
         if (!addTargetingRuleModel.FlagValue.TryParseFlagValue(flag.SettingType, out var parsed))
             throw new ShowHelpException($"Flag value '{addTargetingRuleModel.FlagValue}' must respect the type '{flag.SettingType}'.");
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Replace($"/{FlagValueModel.TargetingRuleJsonName}/{realPosition}", new TargetingModel
         {
@@ -136,6 +142,9 @@ internal class FlagTargeting(
 
         var (_, realPosition) = await this.GetRuleAsync("Choose rule to delete", flag.SettingId, environmentId, position, token);
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Remove($"/{FlagValueModel.TargetingRuleJsonName}/{realPosition}");
 
@@ -157,6 +166,9 @@ internal class FlagTargeting(
         var (_, realFrom) = await this.GetRuleAsync("Choose rule to re-position", flag.SettingId, environmentId, from, token);
         var (_, realTo) = await this.GetRuleAsync("Choose the position to move", flag.SettingId, environmentId, to, token);
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Move($"/{FlagValueModel.TargetingRuleJsonName}/{realFrom}", $"/{FlagValueModel.TargetingRuleJsonName}/{realTo}");
 

--- a/src/ConfigCat.Cli/Commands/Flags/FlagValue.cs
+++ b/src/ConfigCat.Cli/Commands/Flags/FlagValue.cs
@@ -157,6 +157,9 @@ internal class FlagValue(
         if (!flagValue.TryParseFlagValue(value.Setting.SettingType, out var parsed))
             throw new ShowHelpException($"Flag value '{flagValue}' must respect the type '{value.Setting.SettingType}'.");
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Replace($"/value", parsed);
 

--- a/src/ConfigCat.Cli/Commands/Flags/V2/FlagPercentage.cs
+++ b/src/ConfigCat.Cli/Commands/Flags/V2/FlagPercentage.cs
@@ -47,6 +47,9 @@ internal class FlagPercentage(IPrompt prompt, IOutput output, IWorkspaceLoader w
         if (value.Setting.SettingType == SettingTypes.Boolean && result.Count != 2)
             throw new ShowHelpException($"Boolean type can only have 2 percentage rules");
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         percentageRule.PercentageOptions = result;
         await flagValueClient.ReplaceValueAsync(flag.SettingId, environmentId, reason, value, token);
 
@@ -74,6 +77,9 @@ internal class FlagPercentage(IPrompt prompt, IOutput output, IWorkspaceLoader w
             return ExitCodes.Ok;
         }
         
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         value.TargetingRules.Remove(percentageRule);
         await flagValueClient.ReplaceValueAsync(flag.SettingId, environmentId, reason, value, token);
 
@@ -93,6 +99,9 @@ internal class FlagPercentage(IPrompt prompt, IOutput output, IWorkspaceLoader w
 
         if (attributeName.IsEmpty())
             attributeName = await prompt.GetStringAsync("Percentage attribute", token, "Identifier");
+        
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
         
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Replace($"/percentageEvaluationAttribute", attributeName);

--- a/src/ConfigCat.Cli/Commands/Flags/V2/FlagTargeting.cs
+++ b/src/ConfigCat.Cli/Commands/Flags/V2/FlagTargeting.cs
@@ -53,6 +53,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
         var rule = new TargetingRuleModel { Conditions = [new ConditionModel { UserCondition = condition }] };
         await SetRuleThenPart(servedValue, percentageOptions, rule, flag, token);
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Add($"/targetingRules/-", rule);
         await flagValueClient.UpdateValueAsync(flag.SettingId, environmentId, reason, jsonPatchDocument.Operations, token);
@@ -94,6 +97,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
             Comparator = comparator, ComparisonAttribute = attribute,
             ComparisonValue = await ParseComparisonValue(comparator, comparisonValue, token)
         };
+        
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
         
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Add($"/targetingRules/{rulePosition-1}/conditions/-", new ConditionModel { UserCondition = condition });
@@ -140,6 +146,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
         var rule = new TargetingRuleModel { Conditions = [new ConditionModel { SegmentCondition = condition }] };
         await SetRuleThenPart(servedValue, percentageOptions, rule, flag, token);
         
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Add($"/targetingRules/-", rule);
         await flagValueClient.UpdateValueAsync(flag.SettingId, environmentId, reason, jsonPatchDocument.Operations, token);
@@ -182,6 +191,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
             var segment = await workspaceLoader.LoadSegmentAsync(token);
             condition.SegmentId = segment.SegmentId;
         }
+        
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
         
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Add($"/targetingRules/{rulePosition-1}/conditions/-", new ConditionModel { SegmentCondition = condition });
@@ -247,6 +259,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
         var rule = new TargetingRuleModel { Conditions = [new ConditionModel { PrerequisiteFlagCondition = condition }] };
         await SetRuleThenPart(servedValue, percentageOptions, rule, flag, token);
         
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Add($"/targetingRules/-", rule);
         await flagValueClient.UpdateValueAsync(flag.SettingId, environmentId, reason, jsonPatchDocument.Operations, token);
@@ -309,6 +324,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
             condition.PrerequisiteComparisonValue = val.ToFlagValue(prerequisiteFlag.SettingType);
         }
         
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Add($"/targetingRules/{rulePosition-1}/conditions/-", new ConditionModel { PrerequisiteFlagCondition = condition });
         await flagValueClient.UpdateValueAsync(flag.SettingId, environmentId, reason, jsonPatchDocument.Operations, token);
@@ -332,6 +350,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
             environmentId = (await workspaceLoader.LoadEnvironmentAsync(token, flag.ConfigId)).EnvironmentId;
         
         rulePosition ??= await PromptPosition("Targeting rule's position to remove", token);
+        
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
         
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Remove($"/targetingRules/{rulePosition-1}");
@@ -359,6 +380,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
         rulePosition ??= await PromptPosition("Targeting rule's position", token);
         conditionPosition ??= await PromptPosition("Condition's position to remove", token);
         
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Remove($"/targetingRules/{rulePosition-1}/conditions/{conditionPosition-1}");
         await flagValueClient.UpdateValueAsync(flag.SettingId, environmentId, reason, jsonPatchDocument.Operations, token);
@@ -380,6 +404,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
         from ??= await PromptPosition("Move from position", token);
         to ??= await PromptPosition("Move to position", token);
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Move($"/targetingRules/{from-1}", $"/targetingRules/{to-1}");
 
@@ -411,6 +438,9 @@ internal class FlagTargeting(IPrompt prompt, IFlagClient flagClient,
         if (rule is null) throw new ShowHelpException($"Targeting rule in position '{rulePosition}' not found");
         
         await SetRuleThenPart(servedValue, percentageOptions, rule, flag, token);
+        
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
         
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Replace($"/targetingRules/{rulePosition-1}", rule);

--- a/src/ConfigCat.Cli/Commands/Flags/V2/FlagValue.cs
+++ b/src/ConfigCat.Cli/Commands/Flags/V2/FlagValue.cs
@@ -246,6 +246,9 @@ internal class FlagValueV2(
         if (!flagValue.TryParseFlagValue(value.Setting.SettingType, out var parsed))
             throw new ShowHelpException($"Flag value '{flagValue}' must respect the type '{value.Setting.SettingType}'.");
 
+        if (await workspaceLoader.NeedsReasonAsync(environmentId, token) && reason.IsEmpty())
+            reason = await prompt.GetStringAsync("Mandatory reason", token);
+        
         var jsonPatchDocument = new JsonPatchDocument();
         jsonPatchDocument.Replace($"/defaultValue/{flag.SettingType.ToValuePropertyName()}", parsed);
 

--- a/src/ConfigCat.Cli/Commands/Scan.cs
+++ b/src/ConfigCat.Cli/Commands/Scan.cs
@@ -42,6 +42,7 @@ internal class Scan(
         string fileUrlTemplate,
         string commitUrlTemplate,
         string runner,
+        string[] aliasPatterns,
         string[] excludeFlagKeys,
         CancellationToken token)
     {
@@ -75,7 +76,10 @@ internal class Scan(
             deletedFlags = deletedFlags.Where(f => !excludeFlagKeys.Contains(f.Key));
 
         var files = await fileCollector.CollectAsync(directory, token);
-        var flagReferences = await fileScanner.ScanAsync(flags.Concat(deletedFlags).ToArray(), files.ToArray(), lineCount, token);
+
+        var patternsFromEnv =
+            System.Environment.GetEnvironmentVariable(Constants.AliasPatternsEnvironmentVariableName)?.Split(',') ?? [];
+        var flagReferences = await fileScanner.ScanAsync(flags.Concat(deletedFlags).ToArray(), files.ToArray(), patternsFromEnv.Concat(aliasPatterns).ToArray(), lineCount, token);
 
         var flagReferenceResults = flagReferences as FlagReferenceResult[] ?? flagReferences.ToArray();
         var aliveFlagReferences = Filter(flagReferenceResults, r => r.FoundFlag is not DeletedFlagModel).ToArray();

--- a/src/ConfigCat.Cli/Commands/Webhook.cs
+++ b/src/ConfigCat.Cli/Commands/Webhook.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ConfigCat.Cli.Models.Api;
+using ConfigCat.Cli.Services;
+using ConfigCat.Cli.Services.Api;
+using ConfigCat.Cli.Services.Exceptions;
+using ConfigCat.Cli.Services.Json;
+using ConfigCat.Cli.Services.Rendering;
+
+namespace ConfigCat.Cli.Commands;
+
+public class Webhook(
+    IProductClient productClient,
+    IWebhookClient webhookClient,
+    IWorkspaceLoader workspaceLoader,
+    IPrompt prompt,
+    IOutput output)
+{
+     public async Task<int> ListAllWebhooksAsync(string productId, bool json, CancellationToken token)
+    {
+        var webhooks = new List<WebhookModel>();
+        if (!productId.IsEmpty())
+            webhooks.AddRange(await webhookClient.GetWebhooksAsync(productId, token));
+        else
+        {
+            var products = await productClient.GetProductsAsync(token);
+            foreach (var product in products)
+                webhooks.AddRange(await webhookClient.GetWebhooksAsync(product.ProductId, token));
+        }
+
+        if (json)
+        {
+            output.RenderJson(webhooks);
+            return ExitCodes.Ok;
+        }
+
+        var itemsToRender = webhooks.Select(w => new
+        {
+            Id = w.WebhookId,
+            Method = w.HttpMethod,
+            Url = w.Url.TrimToLength(30),
+            Headers = string.Join(", ", w.WebhookHeaders?.Select(wh => wh.Key) ?? []),
+            Environment = $"{w.Environment.Name} [{w.Environment.EnvironmentId}]",
+            Config = $"{w.Config.Name} [{w.Config.ConfigId}]"
+        });
+        output.RenderTable(itemsToRender);
+
+        return ExitCodes.Ok;
+    }
+     
+    public async Task<int> ShowWebhookAsync(int? webhookId, bool json, CancellationToken token)
+    {
+        var webhook = webhookId is null
+            ? await workspaceLoader.LoadWebhookAsync(token)
+            : await webhookClient.GetWebhookAsync(webhookId.Value, token);
+
+        if (json)
+        {
+            output.RenderJson(webhook);
+            return ExitCodes.Ok;
+        }
+
+        output.WriteDarkGray("URL: ").Write(webhook.Url).WriteLine();
+        output.WriteDarkGray("HTTP method: ").Write(webhook.HttpMethod).WriteLine();
+        output.WriteDarkGray("HTTP body: ").Write(webhook.Content).WriteLine();
+        if (!webhook.WebhookHeaders.IsEmpty())
+        {
+            output.WriteDarkGray("HTTP headers: ").WriteLine();
+            output.RenderTable(webhook.WebhookHeaders.Select(wh => new
+            {
+                wh.Key,
+                Value = wh.IsSecure ? "<secure>" : wh.Value
+            }));
+        }
+
+        return ExitCodes.Ok;
+    }
+
+    public async Task<int> CreateWebhookAsync(string configId, 
+        string environmentId,
+        string url,
+        string httpMethod,
+        string content,
+        CancellationToken token)
+    {
+        if (configId.IsEmpty())
+            configId = (await workspaceLoader.LoadConfigAsync(token)).ConfigId;
+        
+        if (environmentId.IsEmpty())
+            environmentId = (await workspaceLoader.LoadEnvironmentAsync(token)).EnvironmentId;
+        
+        if (url.IsEmpty())
+            url = await prompt.GetStringAsync("URL", token);
+
+        if (content.IsEmpty())
+            content = await prompt.GetStringAsync("HTTP body", token, "");
+        
+        if (httpMethod.IsEmpty())
+            httpMethod = await prompt.ChooseFromListAsync("HTTP method", HttpMethods.Collection.ToList(), a => a, token);
+
+        if (!HttpMethods.Collection.ToList()
+                .Contains(httpMethod, StringComparer.OrdinalIgnoreCase))
+            throw new ShowHelpException($"Http method must be one of the following: {string.Join('|', HttpMethods.Collection)}");
+        
+        var result = await webhookClient.CreateWebhookAsync(configId, environmentId, url, httpMethod, content, token);
+        
+        output.Write(result.WebhookId.ToString());
+        return ExitCodes.Ok;
+    }
+
+    public async Task<int> DeleteWebhookAsync(int? webhookId, CancellationToken token)
+    {
+        webhookId ??= (await workspaceLoader.LoadWebhookAsync(token)).WebhookId;
+
+        await webhookClient.DeleteWebhookAsync(webhookId.Value, token);
+        return ExitCodes.Ok;
+    }
+
+    public async Task<int> UpdateWebhookAsync(int? webhookId, 
+        string url,
+        string httpMethod,
+        string content, 
+        CancellationToken token)
+    {
+        var webhook = webhookId is null
+            ? await workspaceLoader.LoadWebhookAsync(token)
+            : await webhookClient.GetWebhookAsync(webhookId.Value, token);
+
+        if (webhookId is null)
+        {
+            if (url.IsEmpty())
+                url = await prompt.GetStringAsync("URL", token, webhook.Url);
+            
+            if (httpMethod.IsEmpty())
+                httpMethod = await prompt.GetStringAsync("HTTP method", token, webhook.HttpMethod);
+            
+            if (content.IsEmpty())
+                content = await prompt.GetStringAsync("HTTP body", token, webhook.Content);
+            
+            if (httpMethod.IsEmpty())
+                httpMethod = await prompt.ChooseFromListAsync("HTTP method", HttpMethods.Collection.ToList(), a => a, token, webhook.HttpMethod);
+        }
+
+        if (url.IsEmptyOrEquals(webhook.Url) &&
+            httpMethod.IsEmptyOrEquals(webhook.HttpMethod) &&
+            content.IsEmptyOrEquals(webhook.Content))
+        {
+            output.WriteNoChange();
+            return ExitCodes.Ok;
+        }
+        
+        var patchDocument = JsonPatch.GenerateDocument(webhook.ToUpdateModel(), new UpdateWebhookModel
+        {
+            Url = url,
+            HttpMethod = httpMethod,
+            Content = content
+        });
+
+        await webhookClient.UpdateWebhookAsync(webhook.WebhookId, patchDocument.Operations, token);
+        return ExitCodes.Ok;
+    }
+    
+    public async Task<int> AddWebhookHeaderAsync(int? webhookId, 
+        string key,
+        string value,
+        bool secure, 
+        CancellationToken token)
+    {
+        var webhook = webhookId is null
+            ? await workspaceLoader.LoadWebhookAsync(token)
+            : await webhookClient.GetWebhookAsync(webhookId.Value, token);
+
+        if (key.IsEmpty())
+            key = await prompt.GetStringAsync("Key", token);
+            
+        if (value.IsEmpty())
+            value = await prompt.GetStringAsync("Value", token);
+
+        var patchDocument = new JsonPatchDocument();
+        patchDocument.Operations.Add(new JsonPatchOperation
+        {
+            Op = "add",
+            Path = "/webHookHeaders/-",
+            Value = new
+            {
+                Key = key,
+                Value = value,
+                IsSecure = secure
+            }
+        });
+
+        await webhookClient.UpdateWebhookAsync(webhook.WebhookId, patchDocument.Operations, token);
+        return ExitCodes.Ok;
+    }
+    
+    public async Task<int> RemoveHeaderAsync(int? webhookId, 
+        string key, 
+        CancellationToken token)
+    {
+        var webhook = webhookId is null
+            ? await workspaceLoader.LoadWebhookAsync(token)
+            : await webhookClient.GetWebhookAsync(webhookId.Value, token);
+
+        if (key.IsEmpty())
+            key = await prompt.GetStringAsync("Key", token);
+
+        var item = webhook.WebhookHeaders?.FirstOrDefault(wh => wh.Key == key);
+
+        if (item is null)
+        {
+            output.WriteNoChange();
+            return ExitCodes.Ok;
+        }
+
+        var index = webhook.WebhookHeaders.ToList().IndexOf(item);
+        
+        var patchDocument = new JsonPatchDocument();
+        patchDocument.Operations.Add(new JsonPatchOperation
+        {
+            Op = "remove",
+            Path = $"/webHookHeaders/{index}"
+        });
+
+        await webhookClient.UpdateWebhookAsync(webhook.WebhookId, patchDocument.Operations, token);
+        return ExitCodes.Ok;
+    }
+}

--- a/src/ConfigCat.Cli/Commands/Webhook.cs
+++ b/src/ConfigCat.Cli/Commands/Webhook.cs
@@ -184,7 +184,7 @@ public class Webhook(
         {
             Op = "add",
             Path = "/webHookHeaders/-",
-            Value = new
+            Value = new WebhookHeaderModel
             {
                 Key = key,
                 Value = value,

--- a/src/ConfigCat.Cli/Extensions/StringExtension.cs
+++ b/src/ConfigCat.Cli/Extensions/StringExtension.cs
@@ -1,7 +1,0 @@
-﻿namespace System;
-
-internal static class StringExtension
-{
-    public static string TrimToFitColumn(this string text)
-        => text == null ? "\"\"" : text.Length > 30 ? $"\"{text[0..28]}...\"" : $"\"{text}\"";
-}

--- a/src/ConfigCat.Cli/Options/ReasonRequiredEnvironmentOption.cs
+++ b/src/ConfigCat.Cli/Options/ReasonRequiredEnvironmentOption.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.CommandLine;
+using System.Linq;
+using ConfigCat.Cli.Models.Api;
+
+namespace ConfigCat.Cli.Options;
+
+public class ReasonRequiredEnvironmentOption : Option<ReasonRequiredEnvironmentModel[]>
+{
+    public ReasonRequiredEnvironmentOption() : base(["--environments", "-ei"], argumentResult =>
+    {
+        var length = argumentResult.Tokens.Count;
+        if (length == 0)
+            return [];
+
+        var result = new ReasonRequiredEnvironmentModel[length];
+        for (var i = 0; i < length; i++)
+        {
+            var value = argumentResult.Tokens.ElementAt(i).Value;
+            var indexOfSeparator = value.IndexOf(':');
+            if (indexOfSeparator == -1)
+            {
+                argumentResult.ErrorMessage = $"The expression `{value}` is invalid. Required format: <environment-id>:<reason-required>";
+                return null;
+            }
+
+            var environmentId = value[..indexOfSeparator];
+            var reasonRequired = value[(indexOfSeparator + 1)..];
+
+            if (!Guid.TryParse(environmentId, out _))
+            {
+                argumentResult.ErrorMessage = $"The <environment-id> part of the expression `{value}` is not a valid GUID.";
+                return null;
+            }
+
+            if (reasonRequired.IsEmpty() || !bool.TryParse(reasonRequired, out var reasonReq))
+            {
+                argumentResult.ErrorMessage = $"The <reason-required> part of the expression `{value}` is not a valid boolean";
+                return null;
+            }
+
+            result[i] = new ReasonRequiredEnvironmentModel { EnvironmentId = environmentId, ReasonRequired = reasonReq };
+        }
+
+        return result;
+    }, false, "Format: `<environment-id>:<reason-required>`.")
+    { }
+}

--- a/test/ConfigCat.Cli.Tests/ConfigCat.Cli.Tests.csproj
+++ b/test/ConfigCat.Cli.Tests/ConfigCat.Cli.Tests.csproj
@@ -31,6 +31,9 @@
     <None Update="refs.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="custom.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/ConfigCat.Cli.Tests/custom.txt
+++ b/test/ConfigCat.Cli.Tests/custom.txt
@@ -1,0 +1,15 @@
+﻿CUS_TEST_FLAG = :test_flag
+
+CUS_ANOTHER_FLAG = :another_flag
+
+Somewhere else refer to CUS_TEST_FLAG
+
+CUS2_TEST_FLAG = client_wrapper.get_flag(:test_flag)
+
+Somewhere else refer to CUS_TEST_FLAG
+
+let is_test_flag_on := FLAGS('test_flag')
+
+Reference to is_test_flag_on
+
+Reference to CUS2_TEST_FLAG

--- a/test/integ.ps1
+++ b/test/integ.ps1
@@ -268,22 +268,22 @@ Describe "Webhook tests" {
 
     It "Add header" {
         Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header1", "-val", "header-val"
-        $hookResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
-        $hookResult | Should -Match ([regex]::Escape("Header1"))
-        $hookResult | Should -Match ([regex]::Escape("header-val"))
+        $addHeaderResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
+        $addHeaderResult | Should -Match ([regex]::Escape("Header1"))
+        $addHeaderResult | Should -Match ([regex]::Escape("header-val"))
 
         Invoke-ConfigCat "webhook", "headers", "rm", "-i", $webhookId, "-k", "Header1"
-        $hookResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
-        $hookResult | Should -Not -Match ([regex]::Escape("Header1"))
-        $hookResult | Should -Not -Match ([regex]::Escape("header-val"))
+        $addHeaderResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
+        $addHeaderResult | Should -Not -Match ([regex]::Escape("Header1"))
+        $addHeaderResult | Should -Not -Match ([regex]::Escape("header-val"))
     }
 
     It "Add secure header" {
         Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header2", "-val", "secure-header-val", "--secure"
-        $hookResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
-        $hookResult | Should -Match ([regex]::Escape("Header2"))
-        $hookResult | Should -Not -Match ([regex]::Escape("secure-header-val"))
-        $hookResult | Should -Match ([regex]::Escape("<secure>"))
+        $addSecureHeaderResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
+        $addSecureHeaderResult | Should -Match ([regex]::Escape("Header2"))
+        $addSecureHeaderResult | Should -Not -Match ([regex]::Escape("secure-header-val"))
+        $addSecureHeaderResult | Should -Match ([regex]::Escape("<secure>"))
     }
 }
 

--- a/test/integ.ps1
+++ b/test/integ.ps1
@@ -251,7 +251,7 @@ Describe "Webhook tests" {
         $tableResult = Invoke-ConfigCat "webhook", "ls", "-p", $productId
         $tableResult | Should -Match ([regex]::Escape($webhookId))
         $tableResult | Should -Match ([regex]::Escape("https://example.com/hook"))
-        $tableResult | Should -Match ([regex]::Escape("GET"))
+        $tableResult | Should -Match ([regex]::Escape("get"))
     }
 
     AfterAll {
@@ -259,11 +259,11 @@ Describe "Webhook tests" {
     }
 
     It "Update webhook" {
-        Invoke-ConfigCat "webhook", "up", "-i", $webhookId, "-u", "https://example.com/hook2", "-m", "post", "-co", "example body"
+        Invoke-ConfigCat "webhook", "up", "-i", $webhookId, "-u", "https://example.com/hook2", "-m", "post", "-co", "example-body"
         $hookResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
         $hookResult | Should -Match ([regex]::Escape("https://example.com/hook2"))
-        $hookResult | Should -Match ([regex]::Escape("POST"))
-        $hookResult | Should -Match ([regex]::Escape("example body"))
+        $hookResult | Should -Match ([regex]::Escape("post"))
+        $hookResult | Should -Match ([regex]::Escape("example-body"))
     }
 
     It "Add header" {
@@ -671,7 +671,7 @@ Describe "Scan Tests" {
     }
     
     It "Scan custom pattern" {
-        $result = Invoke-ConfigCat "scan", $scanPath, "-c", $configId, "-r", "cli", "-ap", "(\w+) = flags!(CC_KEY)", "--print"
+        $result = Invoke-ConfigCat "scan", $scanPath, "-c", $configId, "-r", "cli", "-ap", "'(\w+) = flags!(CC_KEY)'", "--print"
         $result | Should -Match ([regex]::Escape("custom_alias"))
     }
 }

--- a/test/integ.ps1
+++ b/test/integ.ps1
@@ -267,7 +267,8 @@ Describe "Webhook tests" {
     }
 
     It "Add header" {
-        Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header1", "-val", "header-val"
+        $addH = Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header1", "-val", "header-val"
+        Write-Host $addH
         $addHeaderResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
         $addHeaderResult | Should -Match ([regex]::Escape("Header1"))
         $addHeaderResult | Should -Match ([regex]::Escape("header-val"))
@@ -279,7 +280,8 @@ Describe "Webhook tests" {
     }
 
     It "Add secure header" {
-        Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header2", "-val", "secure-header-val", "--secure"
+        $addSH = Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header2", "-val", "secure-header-val", "--secure"
+        Write-Host $addSH
         $addSecureHeaderResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
         $addSecureHeaderResult | Should -Match ([regex]::Escape("Header2"))
         $addSecureHeaderResult | Should -Not -Match ([regex]::Escape("secure-header-val"))

--- a/test/integ.ps1
+++ b/test/integ.ps1
@@ -267,8 +267,7 @@ Describe "Webhook tests" {
     }
 
     It "Add header" {
-        $addH = Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header1", "-val", "header-val"
-        Write-Host $addH
+        Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header1", "-val", "header-val"
         $addHeaderResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
         $addHeaderResult | Should -Match ([regex]::Escape("Header1"))
         $addHeaderResult | Should -Match ([regex]::Escape("header-val"))
@@ -280,8 +279,7 @@ Describe "Webhook tests" {
     }
 
     It "Add secure header" {
-        $addSH = Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header2", "-val", "secure-header-val", "--secure"
-        Write-Host $addSH
+        Invoke-ConfigCat "webhook", "headers", "add", "-i", $webhookId, "-k", "Header2", "-val", "secure-header-val", "--secure"
         $addSecureHeaderResult = Invoke-ConfigCat "webhook", "sh", "-i", $webhookId
         $addSecureHeaderResult | Should -Match ([regex]::Escape("Header2"))
         $addSecureHeaderResult | Should -Not -Match ([regex]::Escape("secure-header-val"))

--- a/test/sample-to-scan2.txt
+++ b/test/sample-to-scan2.txt
@@ -1,3 +1,5 @@
 "flag_to_scan"
 
 "flag_to_scan_2"
+
+custom_alias = flags!(flag_to_scan)


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR adds the following:

- Manage webhooks command.
- Product preferences show/update commands. 
- Prompt for `reason` argument upon flag value changes when it's required to set on the given environment.
- List/delete pending invitation commands.
- `--alias-patterns` option for the `scan` command to describe custom regex patterns for alias matching.

### Related issues (only if applicable)

#23 

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
