### PR TITLE
Don't restrict the alias pattern match groups' order

### DIFF
--- a/test/ConfigCat.Cli.Tests/ScanTests.cs
+++ b/test/ConfigCat.Cli.Tests/ScanTests.cs
@@ -268,6 +268,17 @@ public class ScanTests
 
         Assert.Contains("CUS2_TEST_FLAG = client_wrapper.get_flag(:test_flag)", referenceLines);
         Assert.Contains("Reference to CUS2_TEST_FLAG", referenceLines);
+        
+        result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"client_wrapper\.get_flag\(:CC_KEY, (\w+) =>"], CancellationToken.None);
+        flag.Aliases = result.FlagAliases[flag].ToList();
+        
+        Assert.Contains("cust_flag_val",  flag.Aliases);
+
+        references = await scanner.CollectAsync(new[] { flag }, file, 0, CancellationToken.None);
+        referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
+
+        Assert.Contains("client_wrapper.get_flag(:test_flag, cust_flag_val => {", referenceLines);
+        Assert.Contains("Reference to cust_flag_val", referenceLines);
     }
     
     [Fact]

--- a/test/ConfigCat.Cli.Tests/custom.txt
+++ b/test/ConfigCat.Cli.Tests/custom.txt
@@ -6,6 +6,8 @@ Somewhere else refer to CUS_TEST_FLAG
 
 CUS2_TEST_FLAG = client_wrapper.get_flag(:test_flag)
 
+client_wrapper.get_flag(:test_flag, cust_flag_val => {
+
 Somewhere else refer to CUS_TEST_FLAG
 
 let is_test_flag_on := FLAGS('test_flag')
@@ -13,3 +15,5 @@ let is_test_flag_on := FLAGS('test_flag')
 Reference to is_test_flag_on
 
 Reference to CUS2_TEST_FLAG
+
+Reference to cust_flag_val


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR fixes the bug where the strict order of the alias pattern match groups disallowed to do the following:

```
configcat scan <dir> --alias-patterns "wrapper\.get_value\(CC_KEY\)\.then\((\w+) =>"
```

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
