### PR TITLE
Ability to pass custom flag key usage patterns to scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache \
         git \

--- a/docs/configcat-scan.md
+++ b/docs/configcat-scan.md
@@ -23,6 +23,7 @@ configcat scan ./dir -c <config-id> -l 5 --print
 | `--runner`, `-ru` | Overrides the default `ConfigCat CLI {version}` executor label on the ConfigCat dashboard |
 | `--exclude-flag-keys`, `-ex` | Exclude the given Feature Flag keys from scanning. E.g.: `-ex flag1 flag2` or `-ex 'flag1,flag2'` |
 | `--alias-patterns`, `-ap` | List of custom regex patterns used to search for additional aliases |
+| `--usage-patterns`, `-up` | List of custom regex patterns that describe additional feature flag key usages |
 | `--verbose`, `-v`, `/v` | Print detailed execution information |
 | `--non-interactive`, `-ni` | Turn off progress rendering and interactive features |
 | `-h`, `/h`, `--help`, `-?`, `/?` | Show help and usage information |

--- a/src/ConfigCat.Cli.Services/Constants.cs
+++ b/src/ConfigCat.Cli.Services/Constants.cs
@@ -12,6 +12,9 @@ public static class Constants
     public const string ApiUserNameEnvironmentVariableName = "CONFIGCAT_API_USER";
     public const string ApiPasswordEnvironmentVariableName = "CONFIGCAT_API_PASS";
     public const string AliasPatternsEnvironmentVariableName = "CONFIGCAT_ALIAS_PATTERNS";
+    public const string UsagePatternsEnvironmentVariableName = "CONFIGCAT_USAGE_PATTERNS";
+
+    public const string KeyPatternPlaceHolder = "CC_KEY";
 
     public static readonly string ConfigFilePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),

--- a/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
@@ -84,10 +84,10 @@ public class AliasCollector : IAliasCollector
                     {
                         foreach (var matchPattern in matchPatterns)
                         {
-                            if (!matchPattern.Contains("CC_KEY"))
+                            if (!matchPattern.Contains(Constants.KeyPatternPlaceHolder))
                                 continue;
                             
-                            var regMatch = Regex.Match(line, matchPattern.Replace("CC_KEY", $"[`'\"]?(?<keys>{keys})[`'\"]?"), RegexOptions.Compiled);
+                            var regMatch = Regex.Match(line, matchPattern.Replace(Constants.KeyPatternPlaceHolder, $"[`'\"]?(?<keys>{keys})[`'\"]?"), RegexOptions.Compiled);
                             while (regMatch.Success && !cancellation.IsCancellationRequested)
                             {
                                 var keyGroup = regMatch.Groups["keys"];

--- a/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
+++ b/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
@@ -16,6 +16,7 @@ public interface IFileScanner
     Task<IEnumerable<FlagReferenceResult>> ScanAsync(FlagModel[] flags,
         FileInfo[] filesToScan,
         string[] matchPatterns,
+        string[] usagePatterns,
         int contextLines,
         CancellationToken token);
 }
@@ -42,6 +43,7 @@ public class FileScanner : IFileScanner
     public async Task<IEnumerable<FlagReferenceResult>> ScanAsync(FlagModel[] flags,
         FileInfo[] filesToScan,
         string[] matchPatterns,
+        string[] usagePatterns,
         int contextLines,
         CancellationToken token)
     {
@@ -69,7 +71,7 @@ public class FileScanner : IFileScanner
             var scanTasks = aliasResults
                 .Select(r => r.ScannedFile)
                 .TakeWhile(file => !cancellation.IsCancellationRequested)
-                .Select(file => this.referenceCollector.CollectAsync(foundFlags, file, contextLines, cancellation));
+                .Select(file => this.referenceCollector.CollectAsync(foundFlags, file, contextLines, usagePatterns, cancellation));
 
             var referenceResults = (await Task.WhenAll(scanTasks)).Where(r => r is not null);
 

--- a/src/ConfigCat.Cli/CommandBuilder.cs
+++ b/src/ConfigCat.Cli/CommandBuilder.cs
@@ -1303,6 +1303,7 @@ public static class CommandBuilder
                 new Option<string>(["--runner", "-ru"], "Overrides the default `ConfigCat CLI {version}` executor label on the ConfigCat dashboard"),
                 new Option<string[]>(["--exclude-flag-keys", "-ex"], "Exclude the given Feature Flag keys from scanning. E.g.: `-ex flag1 flag2` or `-ex 'flag1,flag2'`"),
                 new Option<string[]>(["--alias-patterns", "-ap"], "List of custom regex patterns used to search for additional aliases"),
+                new Option<string[]>(["--usage-patterns", "-up"], "List of custom regex patterns that describe additional feature flag key usages"),
 
             }
         };

--- a/src/ConfigCat.Cli/Commands/Scan.cs
+++ b/src/ConfigCat.Cli/Commands/Scan.cs
@@ -43,6 +43,7 @@ internal class Scan(
         string commitUrlTemplate,
         string runner,
         string[] aliasPatterns,
+        string[] usagePatterns,
         string[] excludeFlagKeys,
         CancellationToken token)
     {
@@ -79,7 +80,10 @@ internal class Scan(
 
         var patternsFromEnv =
             System.Environment.GetEnvironmentVariable(Constants.AliasPatternsEnvironmentVariableName)?.Split(',') ?? [];
-        var flagReferences = await fileScanner.ScanAsync(flags.Concat(deletedFlags).ToArray(), files.ToArray(), patternsFromEnv.Concat(aliasPatterns).ToArray(), lineCount, token);
+        var usagePatternsFromEnv = 
+            System.Environment.GetEnvironmentVariable(Constants.UsagePatternsEnvironmentVariableName)?.Split(',') ?? [];
+        var flagReferences = await fileScanner.ScanAsync(flags.Concat(deletedFlags).ToArray(), files.ToArray(), 
+            patternsFromEnv.Concat(aliasPatterns).ToArray(), usagePatternsFromEnv.Concat(usagePatterns).ToArray(), lineCount, token);
 
         var flagReferenceResults = flagReferences as FlagReferenceResult[] ?? flagReferences.ToArray();
         var aliveFlagReferences = Filter(flagReferenceResults, r => r.FoundFlag is not DeletedFlagModel).ToArray();


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR contains the following:
- Ability to pass custom flag key usage patterns to the scan command via a `--usage-patterns` command line arg or via the `CONFIGCAT_USAGE_PATTERNS` environment variable.

### Related issues (only if applicable)

- #23 

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
