### PR TITLE
Fix bug where the scan was strictly based on the alias result

### DIFF
--- a/src/ConfigCat.Cli.Models/Scan/AliasScanResult.cs
+++ b/src/ConfigCat.Cli.Models/Scan/AliasScanResult.cs
@@ -8,7 +8,5 @@ public class AliasScanResult
 {
     public FileInfo ScannedFile { get; set; }
 
-    public ConcurrentDictionary<FlagModel, ConcurrentBag<string>> FlagAliases { get; set; } = new ConcurrentDictionary<FlagModel, ConcurrentBag<string>>();
-
-    public ConcurrentBag<FlagModel> FoundFlags { get; set; } = [];
+    public ConcurrentDictionary<string, ConcurrentBag<string>> FlagAliases { get; set; } = new();
 }

--- a/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
@@ -71,11 +71,8 @@ public class AliasCollector : IAliasCollector
                         var found = match.Groups[1].Value;
                         var flag = flags.FirstOrDefault(f => f.Key == key);
 
-                        if (flag != null)
-                            result.FoundFlags.Add(flag);
-
                         if (flag != null && !found.IsEmpty() && Similarity(flag.Key, found) > 0.3)
-                            result.FlagAliases.AddOrUpdate(flag, [found], (k, v) => { v.Add(found); return v; });
+                            result.FlagAliases.AddOrUpdate(flag.Key, [found], (k, v) => { v.Add(found); return v; });
 
                         match = match.NextMatch();
                     }
@@ -100,11 +97,8 @@ public class AliasCollector : IAliasCollector
 
                                 var flag = flags.FirstOrDefault(f => f.Key == keyGroup.Value);
 
-                                if (flag != null)
-                                    result.FoundFlags.Add(flag);
-
                                 if (flag != null && !found.Value.IsEmpty())
-                                    result.FlagAliases.AddOrUpdate(flag, [found.Value], (k, v) => { v.Add(found.Value); return v; });
+                                    result.FlagAliases.AddOrUpdate(flag.Key, [found.Value], (k, v) => { v.Add(found.Value); return v; });
 
                                 regMatch = regMatch.NextMatch();
                             }

--- a/test/ConfigCat.Cli.Tests/custom.txt
+++ b/test/ConfigCat.Cli.Tests/custom.txt
@@ -17,3 +17,6 @@ Reference to is_test_flag_on
 Reference to CUS2_TEST_FLAG
 
 Reference to cust_flag_val
+
+if FLAGS.enabled(:test_direct) {
+}


### PR DESCRIPTION
### Describe the purpose of your pull request

Previously, the direct flag key search was based on the result of the alias search because it was supposed to find the used feature flag keys. The newly added `--usage-patterns` option broke this functionality as it allows to define custom flag key formats without letting the alias collector know about these. 

So, if there were no alias for a key format defined in `--usage-patterns`, the scan yielded no results for that specific key.

This PR changes this functionality. The direct search is no longer based on only the flags in the alias result.

### Related issues (only if applicable)

- #23 

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
