### PR TITLE
Order uploaded references by importance, define a maximum ref count

### DIFF
--- a/src/ConfigCat.Cli.Models/ConfigCat.Cli.Models.csproj
+++ b/src/ConfigCat.Cli.Models/ConfigCat.Cli.Models.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/src/ConfigCat.Cli.Models/Scan/Reference.cs
+++ b/src/ConfigCat.Cli.Models/Scan/Reference.cs
@@ -14,5 +14,7 @@ namespace ConfigCat.Cli.Models.Scan
         public List<Line> PostLines { get; set; } = new List<Line>();
 
         public Line ReferenceLine { get; set; }
+
+        public bool IsAlias { get; set; }
     }
 }

--- a/src/ConfigCat.Cli.Services/ConfigCat.Cli.Services.csproj
+++ b/src/ConfigCat.Cli.Services/ConfigCat.Cli.Services.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="Trybot" Version="2.4.4" />
   </ItemGroup>
 

--- a/src/ConfigCat.Cli.Services/FileSystem/FileCollector.cs
+++ b/src/ConfigCat.Cli.Services/FileSystem/FileCollector.cs
@@ -32,7 +32,7 @@ public class FileCollector(IOutput output) : IFileCollector
             .Cast<IgnorePolicy>()
             .ToList();
 
-        ignores.Add(new GlobalIgnorePolicy(rootDirectory, "**/.git/**"));
+        ignores.Add(new GlobalIgnorePolicy(rootDirectory, "**/.git/**", "*.lock", "*lock.json", "*.graphql", "*.md", ".dockerignore"));
 
         foreach (var ignore in ignores)
         {

--- a/src/ConfigCat.Cli.Services/Rendering/Output.cs
+++ b/src/ConfigCat.Cli.Services/Rendering/Output.cs
@@ -103,7 +103,7 @@ public class Output(CliOptions options) : IOutput
             return this;
         }
     }
-
+    
     public IOutput WriteGreen(string text) => this.WriteColor(text, ConsoleColor.Green);
 
     public IOutput WriteYellow(string text) => this.WriteColor(text, ConsoleColor.Yellow);

--- a/src/ConfigCat.Cli/ConfigCat.Cli.csproj
+++ b/src/ConfigCat.Cli/ConfigCat.Cli.csproj
@@ -78,9 +78,9 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Stashbox" Version="5.14.0" />
+    <PackageReference Include="Stashbox" Version="5.14.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ConfigCat.Cli.Tests/ConfigCat.Cli.Tests.csproj
+++ b/test/ConfigCat.Cli.Tests/ConfigCat.Cli.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/ConfigCat.Cli.Tests/ScanTests.cs
+++ b/test/ConfigCat.Cli.Tests/ScanTests.cs
@@ -22,7 +22,7 @@ public class ScanTests
         var flag = new FlagModel { Key = "test_flag" };
         var flag2 = new FlagModel { Key = "leadershipSurvey" };
 
-        var result = await aliasCollector.CollectAsync(new[] { flag, flag2 }, new FileInfo("alias.txt"), [], CancellationToken.None);
+        var result = await aliasCollector.CollectAsync(new[] { flag, flag2 }, new FileInfo("alias.txt"), [], [], CancellationToken.None);
 
         var aliases = result.FlagAliases.Values.SelectMany(v => v);
 
@@ -77,10 +77,10 @@ public class ScanTests
         var flag = new FlagModel { Key = "test_flag", SettingType = "boolean" };
         var file = new FileInfo("refs.txt");
 
-        var result = await aliasCollector.CollectAsync(new[] { flag }, file, [], CancellationToken.None);
+        var result = await aliasCollector.CollectAsync(new[] { flag }, file, [], [], CancellationToken.None);
         flag.Aliases = result.FlagAliases[flag.Key].ToList();
 
-        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], CancellationToken.None);
+        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
 
         var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
 
@@ -226,12 +226,12 @@ public class ScanTests
         var flag = new FlagModel { Key = "test_flag", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
-        var result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) = :CC_KEY"], CancellationToken.None);
+        var result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) = :CC_KEY"], [], CancellationToken.None);
         flag.Aliases = result.FlagAliases[flag.Key].ToList();
         
         Assert.Contains("CUS_TEST_FLAG",  flag.Aliases);
 
-        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], CancellationToken.None);
+        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
         var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
 
         Assert.Contains("CUS_TEST_FLAG = :test_flag", referenceLines);
@@ -247,34 +247,34 @@ public class ScanTests
         var flag = new FlagModel { Key = "test_flag", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
-        var result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) := FLAGS(CC_KEY)"], CancellationToken.None);
+        var result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) := FLAGS(CC_KEY)"], [], CancellationToken.None);
         flag.Aliases = result.FlagAliases[flag.Key].ToList();
         
         Assert.Contains("is_test_flag_on",  flag.Aliases);
 
-        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], CancellationToken.None);
+        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
         var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
 
         Assert.Contains("let is_test_flag_on := FLAGS('test_flag')", referenceLines);
         Assert.Contains("Reference to is_test_flag_on", referenceLines);
         
-        result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) = client_wrapper\.get_flag\(:CC_KEY\)"], CancellationToken.None);
+        result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) = client_wrapper\.get_flag\(:CC_KEY\)"], [], CancellationToken.None);
         flag.Aliases = result.FlagAliases[flag.Key].ToList();
         
         Assert.Contains("CUS2_TEST_FLAG",  flag.Aliases);
 
-        references = await scanner.CollectAsync(new[] { flag }, file, 0, [], CancellationToken.None);
+        references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
         referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
 
         Assert.Contains("CUS2_TEST_FLAG = client_wrapper.get_flag(:test_flag)", referenceLines);
         Assert.Contains("Reference to CUS2_TEST_FLAG", referenceLines);
         
-        result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"client_wrapper\.get_flag\(:CC_KEY, (\w+) =>"], CancellationToken.None);
+        result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"client_wrapper\.get_flag\(:CC_KEY, (\w+) =>"], [], CancellationToken.None);
         flag.Aliases = result.FlagAliases[flag.Key].ToList();
         
         Assert.Contains("cust_flag_val",  flag.Aliases);
 
-        references = await scanner.CollectAsync(new[] { flag }, file, 0, [], CancellationToken.None);
+        references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
         referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
 
         Assert.Contains("client_wrapper.get_flag(:test_flag, cust_flag_val => {", referenceLines);
@@ -289,7 +289,7 @@ public class ScanTests
         var flag = new FlagModel { Key = "another_flag", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
-        var result = await aliasCollector.CollectAsync(new[] { flag }, file, [":CC_KEY"], CancellationToken.None);
+        var result = await aliasCollector.CollectAsync(new[] { flag }, file, [":CC_KEY"], [], CancellationToken.None);
         Assert.Empty(result.FlagAliases);
     }
     
@@ -302,12 +302,12 @@ public class ScanTests
         var flag = new FlagModel { Key = "test_flag", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
-        var result = await aliasCollector.CollectAsync([flag], file, [@"(\w+) = client_wrapper\.get_flag\(:CC_KEY\)"], CancellationToken.None);
+        var result = await aliasCollector.CollectAsync([flag], file, [@"(\w+) = client_wrapper\.get_flag\(:CC_KEY\)"], [], CancellationToken.None);
         flag.Aliases = result.FlagAliases[flag.Key].ToList();
         
         Assert.Contains("is_test_flag_on",  flag.Aliases);
 
-        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [@"get_flag\(:CC_KEY"], CancellationToken.None);
+        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [@"get_flag\(:CC_KEY"], [], CancellationToken.None);
         var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
 
         Assert.Contains("let is_test_flag_on := FLAGS('test_flag')", referenceLines);
@@ -326,10 +326,10 @@ public class ScanTests
         var flag = new FlagModel { Key = "test_direct", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
-        var result = await aliasCollector.CollectAsync([flag], file, [], CancellationToken.None);
+        var result = await aliasCollector.CollectAsync([flag], file, [], [], CancellationToken.None);
         Assert.Empty(result.FlagAliases);
 
-        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [":CC_KEY"], CancellationToken.None);
+        var references = await scanner.CollectAsync(new[] { flag }, file, 0, [":CC_KEY"], [], CancellationToken.None);
         var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
 
         Assert.Contains("if FLAGS.enabled(:test_direct) {", referenceLines);


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR contains the following:
- Order uploaded references by importance. (direct references take precedence over aliases)
- Max `150` reference is uploaded (/flag) from the ordered reference list.
- Added more glob patterns to the scan ignore list. (`*.md`, `*.lock` etc.)
- Collect and print warnings during scanning. (timeout, max allowed char count /line reached)
  These were only printed to the verbose logs.
- Updated `System.Text.Json` package due to security vulnerability.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
