### PR TITLE
Remove per file scan timeout

### DIFF
--- a/src/ConfigCat.Cli.Models/Api/FlagValueV2Model.cs
+++ b/src/ConfigCat.Cli.Models/Api/FlagValueV2Model.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using ConfigCat.Cli.Models.ConfigFile;
+﻿using System.Collections.Generic;
 
 namespace ConfigCat.Cli.Models.Api;
 

--- a/src/ConfigCat.Cli.Models/Api/UpdateFlagModel.cs
+++ b/src/ConfigCat.Cli.Models/Api/UpdateFlagModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace ConfigCat.Cli.Models.Api;
 

--- a/src/ConfigCat.Cli.Models/Scan/AliasScanResult.cs
+++ b/src/ConfigCat.Cli.Models/Scan/AliasScanResult.cs
@@ -1,5 +1,4 @@
-﻿using ConfigCat.Cli.Models.Api;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.IO;
 
 namespace ConfigCat.Cli.Models.Scan;

--- a/src/ConfigCat.Cli.Services/ConfigFile/ConfigJsonConverter.cs
+++ b/src/ConfigCat.Cli.Services/ConfigFile/ConfigJsonConverter.cs
@@ -1,8 +1,6 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;

--- a/src/ConfigCat.Cli.Services/Extensions/IOExtensions.cs
+++ b/src/ConfigCat.Cli.Services/Extensions/IOExtensions.cs
@@ -9,10 +9,10 @@ public static class FileSystemExtensions
 {
     public static bool IsIgnoreFile(this FileInfo info) => IgnoreFile.IgnoreFileNames.Contains(info.Name);
 
-    public static async Task<bool> IsBinaryAsync(this FileStream stream, CancellationToken token)
+    public static async Task<bool> IsBinaryAsync(this FileInfo file, CancellationToken token)
     {
         const int readLimit = 8000;
-
+        await using var stream = file.OpenRead();
         var readBuffer = new byte[readLimit];
         var readBytes = await stream.ReadAsync(readBuffer, token);
 

--- a/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
@@ -4,125 +4,117 @@ using System.IO;
 using ConfigCat.Cli.Models.Api;
 using System.Threading;
 using Trybot;
-using Trybot.Timeout.Exceptions;
 using ConfigCat.Cli.Services.Rendering;
 using System;
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using System.Linq;
-using ConfigCat.Cli.Models.Scan;
 using System.Collections.ObjectModel;
 
 namespace ConfigCat.Cli.Services.Scan;
 
 public interface IAliasCollector
 {
-    Task<AliasScanResult> CollectAsync(FlagModel[] flags,
+    Task<ConcurrentDictionary<string, ConcurrentBag<string>>> CollectAsync(FlagModel[] flags,
         FileInfo fileToScan,
         string[] matchPatterns,
-        ConcurrentBag<string> warningTracker,
+        List<string> warningTracker,
         CancellationToken token);
 }
 
-public class AliasCollector : IAliasCollector
+public class AliasCollector(IOutput output) : IAliasCollector
 {
-    private readonly IBotPolicy<AliasScanResult> botPolicy;
-    private readonly IOutput output;
-
-    public AliasCollector(IBotPolicy<AliasScanResult> botPolicy,
-        IOutput output)
+    public async Task<ConcurrentDictionary<string, ConcurrentBag<string>>> CollectAsync(FlagModel[] flags,
+        FileInfo fileToScan,
+        string[] matchPatterns, List<string> warningTracker, CancellationToken token)
     {
-        this.botPolicy = botPolicy;
-        this.output = output;
-
-        this.botPolicy.Configure(p => p.Timeout(t => t.After(TimeSpan.FromSeconds(60))));
-    }
-
-    public async Task<AliasScanResult> CollectAsync(FlagModel[] flags, FileInfo fileToScan,
-        string[] matchPatterns, ConcurrentBag<string> warningTracker, CancellationToken token)
-    {
-        try
+        if (await fileToScan.IsBinaryAsync(token))
         {
-            return await this.botPolicy.ExecuteAsync(async (ctx, cancellation) =>
-            {
-                await using var stream = fileToScan.OpenRead();
-                if (await stream.IsBinaryAsync(cancellation))
-                {
-                    this.output.Verbose($"{fileToScan.FullName} is binary, skipping.", ConsoleColor.Yellow);
-                    return null;
-                }
-
-                this.output.Verbose($"{fileToScan.FullName} - searching aliases...");
-
-                var flagKeys = flags.Select(f => f.Key).ToArray();
-                var keys = string.Join('|', flagKeys);
-
-                var result = new AliasScanResult { ScannedFile = fileToScan };
-
-                Parallel.ForEach(File.ReadLines(fileToScan.FullName), (line, _, index) =>
-                {
-                    if (line.Length > Constants.MaxCharCountPerLine)
-                    {
-                        warningTracker.Add($"{fileToScan.FullName} - {index + 1}. line is longer than allowed ({Constants.MaxCharCountPerLine} chars), skipping alias search.");
-                        return;
-                    }
-
-                    if (!flagKeys.Any(line.Contains))
-                        return;
-
-                    var match = Regex.Match(line, @"[`{'""]?([a-zA-Z_$0-9]*)[[`}'\""]?\s*(?>\:?\s*(?>[sS]tring)?\s*=?>?\s*(?>new|await)?)\s*\S*[@$]?[`'""](" + keys + ")[`'\"]",
-                        RegexOptions.Compiled);
-                    
-                    while (match.Success && !cancellation.IsCancellationRequested)
-                    {
-                        var key = match.Groups[2].Value;
-                        var found = match.Groups[1].Value;
-                        var flag = flags.FirstOrDefault(f => f.Key == key);
-
-                        if (flag != null && !found.IsEmpty() && Similarity(flag.Key, found) > 0.3)
-                            result.FlagAliases.AddOrUpdate(flag.Key, [found], (k, v) => { v.Add(found); return v; });
-
-                        match = match.NextMatch();
-                    }
-
-                    if (matchPatterns.Length != 0)
-                    {
-                        foreach (var matchPattern in matchPatterns)
-                        {
-                            if (!matchPattern.Contains(Constants.KeyPatternPlaceHolder))
-                                continue;
-                            
-                            var regMatch = Regex.Match(line, matchPattern.Replace(Constants.KeyPatternPlaceHolder, $"[`'\"]?(?<keys>{keys})[`'\"]?"), RegexOptions.Compiled);
-                            while (regMatch.Success && !cancellation.IsCancellationRequested)
-                            {
-                                var keyGroup = regMatch.Groups["keys"];
-                                var found = regMatch.Groups.Values.Skip(1).Except([keyGroup]).FirstOrDefault();
-                                if (found is null)
-                                {
-                                    regMatch = regMatch.NextMatch();
-                                    continue;
-                                }
-
-                                var flag = flags.FirstOrDefault(f => f.Key == keyGroup.Value);
-
-                                if (flag != null && !found.Value.IsEmpty())
-                                    result.FlagAliases.AddOrUpdate(flag.Key, [found.Value], (k, v) => { v.Add(found.Value); return v; });
-
-                                regMatch = regMatch.NextMatch();
-                            }
-                        }
-                    }
-                });
-
-                this.output.Verbose($"{fileToScan.FullName} - alias search completed.", ConsoleColor.Green);
-                return result;
-            }, token);
-        }
-        catch (OperationTimeoutException)
-        {
-            warningTracker.Add($"{fileToScan.FullName} - alias search timed out.");
+            output.Verbose($"{fileToScan.FullName} is binary, skipping.", ConsoleColor.Yellow);
             return null;
         }
+
+        output.Verbose($"{fileToScan.FullName} - searching aliases...");
+
+        var flagKeys = flags.Select(f => f.Key).ToArray();
+        var keys = string.Join('|', flagKeys);
+
+        var aliases = new ConcurrentDictionary<string, ConcurrentBag<string>>();
+
+        var lineNumber = 1;
+        var lines = File.ReadLinesAsync(fileToScan.FullName, token);
+        await foreach (var line in lines)
+        {
+            if (line.Length > Constants.MaxCharCountPerLine)
+            {
+                warningTracker.Add(
+                    $"{fileToScan.FullName} - {lineNumber}. line is longer than allowed ({Constants.MaxCharCountPerLine} chars), skipping alias search.");
+                continue;
+            }
+
+            if (!flagKeys.Any(line.Contains))
+                continue;
+
+            var match = Regex.Match(line,
+                @"[`{'""]?([a-zA-Z_$0-9]*)[[`}'\""]?\s*(?>\:?\s*(?>[sS]tring)?\s*=?>?\s*(?>new|await)?)\s*\S*[@$]?[`'""](" +
+                keys + ")[`'\"]",
+                RegexOptions.Compiled);
+
+            while (match.Success && !token.IsCancellationRequested)
+            {
+                var key = match.Groups[2].Value;
+                var found = match.Groups[1].Value;
+                var flag = flags.FirstOrDefault(f => f.Key == key);
+
+                if (flag != null && !found.IsEmpty() && Similarity(flag.Key, found) > 0.3)
+                    aliases.AddOrUpdate(flag.Key, [found], (k, v) =>
+                    {
+                        v.Add(found);
+                        return v;
+                    });
+
+                match = match.NextMatch();
+            }
+
+            if (matchPatterns.Length != 0)
+            {
+                foreach (var matchPattern in matchPatterns)
+                {
+                    if (!matchPattern.Contains(Constants.KeyPatternPlaceHolder))
+                        continue;
+
+                    var regMatch = Regex.Match(line,
+                        matchPattern.Replace(Constants.KeyPatternPlaceHolder, $"[`'\"]?(?<keys>{keys})[`'\"]?"),
+                        RegexOptions.Compiled);
+                    while (regMatch.Success && !token.IsCancellationRequested)
+                    {
+                        var keyGroup = regMatch.Groups["keys"];
+                        var found = regMatch.Groups.Values.Skip(1).Except([keyGroup]).FirstOrDefault();
+                        if (found is null)
+                        {
+                            regMatch = regMatch.NextMatch();
+                            continue;
+                        }
+
+                        var flag = flags.FirstOrDefault(f => f.Key == keyGroup.Value);
+
+                        if (flag != null && !found.Value.IsEmpty())
+                            aliases.AddOrUpdate(flag.Key, [found.Value], (k, v) =>
+                            {
+                                v.Add(found.Value);
+                                return v;
+                            });
+
+                        regMatch = regMatch.NextMatch();
+                    }
+                }
+            }
+
+            lineNumber++;
+        }
+
+        output.Verbose($"{fileToScan.FullName} - alias search completed.", ConsoleColor.Green);
+        return aliases;
     }
 
     private static double Similarity(string a, string b)
@@ -158,6 +150,7 @@ public class AliasCollector : IAliasCollector
                 else
                     shingles[shingle] = 1;
             }
+
             return new ReadOnlyDictionary<string, int>(shingles);
         }
 
@@ -181,6 +174,7 @@ public class AliasCollector : IAliasCollector
 
                 distance += Math.Abs(v1 - v2);
             }
+
             return distance;
         }
     }

--- a/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/AliasCollector.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using ConfigCat.Cli.Models.Api;
 using System.Threading;
-using Trybot;
 using ConfigCat.Cli.Services.Rendering;
 using System;
 using System.Collections.Concurrent;

--- a/src/ConfigCat.Cli.Services/Scan/ReferenceCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/ReferenceCollector.cs
@@ -53,7 +53,7 @@ public class ReferenceCollector(IOutput output) : IReferenceCollector
             {
                 warningTracker.Add(
                     $"{file.FullName} - {lineNumber}. line is longer than allowed ({Constants.MaxCharCountPerLine} chars), skipping code reference scan.");
-                lineTracker.AddLine("<line was too long>", lineNumber);
+                lineTracker.AddLine("(truncated)", lineNumber);
                 lineNumber++;
                 continue;
             }

--- a/src/ConfigCat.Cli.Services/Scan/ReferenceCollector.cs
+++ b/src/ConfigCat.Cli.Services/Scan/ReferenceCollector.cs
@@ -2,13 +2,10 @@
 using ConfigCat.Cli.Models.Scan;
 using ConfigCat.Cli.Services.Rendering;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Trybot;
-using Trybot.Timeout.Exceptions;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -16,112 +13,85 @@ namespace ConfigCat.Cli.Services.Scan;
 
 public interface IReferenceCollector
 {
-    Task<FlagReferenceResult> CollectAsync(IEnumerable<FlagModel> flags, FileInfo file, int contextLines, 
-        string[] usagePatterns, ConcurrentBag<string> warningTracker, CancellationToken token);
+    Task<FlagReferenceResult> CollectAsync(IEnumerable<FlagModel> flags, FileInfo file, int contextLines,
+        string[] usagePatterns, List<string> warningTracker, CancellationToken token);
 }
 
-public class ReferenceCollector : IReferenceCollector
+public class ReferenceCollector(IOutput output) : IReferenceCollector
 {
     private static readonly string[] Prefixes = ["::", ".", "->"];
-    private readonly IBotPolicy<FlagReferenceResult> botPolicy;
-    private readonly IOutput output;
 
-    public ReferenceCollector(IBotPolicy<FlagReferenceResult> botPolicy,
-        IOutput output)
+    public async Task<FlagReferenceResult> CollectAsync(IEnumerable<FlagModel> flags, FileInfo file, int contextLines,
+        string[] usagePatterns, List<string> warningTracker, CancellationToken token)
     {
-        this.botPolicy = botPolicy;
-        this.output = output;
-
-        this.botPolicy.Configure(p => p.Timeout(t => t.After(TimeSpan.FromSeconds(60))));
-    }
-
-    public async Task<FlagReferenceResult> CollectAsync(IEnumerable<FlagModel> flags, FileInfo file, int contextLines, 
-        string[] usagePatterns, ConcurrentBag<string> warningTracker, CancellationToken token)
-    {
-        try
+        if (await file.IsBinaryAsync(token))
         {
-            return await this.botPolicy.ExecuteAsync(async (ctx, cancellation) =>
-            {
-                await using var stream = file.OpenRead();
-                if (await stream.IsBinaryAsync(cancellation))
-                {
-                    this.output.Verbose($"{file.FullName} is binary, skipping.", ConsoleColor.Yellow);
-                    return null;
-                }
-
-                this.output.Verbose($"{file.FullName} - scanning...");
-
-                var lineTracker = new LineTracker(contextLines);
-                var lineNumber = 1;
-
-                var flagSamples = flags.Select(f => new FlagSample
-                {
-                    Flag = f,
-                    KeySamples = ProduceKeySamples(f).Distinct().ToArray(),
-                    Samples = ProduceVariationSamples(f).Distinct().ToArray(),
-                    UsagePatterns = usagePatterns
-                        .Where(p => p.Contains(Constants.KeyPatternPlaceHolder))
-                        .Select(p => new Regex(p.Replace(Constants.KeyPatternPlaceHolder, f.Key), RegexOptions.Compiled))
-                        .ToArray()
-                }).ToArray();
-
-                using var reader = new StreamReader(stream);
-                while (!reader.EndOfStream && !cancellation.IsCancellationRequested)
-                {
-                    var line = await reader.ReadLineAsync(cancellation);
-                    if (line is not null)
-                    {
-                        if (line.Length > Constants.MaxCharCountPerLine)
-                        {
-                            warningTracker.Add(
-                                $"{file.FullName} - {lineNumber}. line is longer than allowed ({Constants.MaxCharCountPerLine} chars), skipping code reference scan.");
-                            lineTracker.AddLine("<line was too long>", lineNumber);
-                            lineNumber++;
-                            continue;
-                        }
-
-                        foreach (var flagSample in flagSamples)
-                        {
-                            if (flagSample.KeySamples.Any(k => line.Contains(k)) ||
-                                flagSample.UsagePatterns.Any(p => p.IsMatch(line)))
-                            {
-                                lineTracker.TrackReference(flagSample.Flag, line, lineNumber);
-                                continue;
-                            }
-
-                            if (flagSample.Flag.Aliases.Any(a => line.Contains(a)))
-                            {
-                                lineTracker.TrackReference(flagSample.Flag, line, lineNumber, isAlias: true);
-                                continue;
-                            }
-
-                            foreach (var sample in flagSample.Samples)
-                            {
-                                if (line.Contains(sample, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    var originalFromLine = line.IndexOf(sample, StringComparison.OrdinalIgnoreCase);
-                                    lineTracker.TrackReference(flagSample.Flag, line, lineNumber,
-                                        line.Substring(originalFromLine, sample.Length).Remove(Prefixes));
-                                }
-                            }
-                        }
-                    }
-
-                    lineTracker.AddLine(line, lineNumber);
-                    lineNumber++;
-                }
-
-                lineTracker.FinishAll();
-
-                this.output.Verbose($"{file.FullName} - scan completed.", ConsoleColor.Green);
-                return new FlagReferenceResult { File = file, References = lineTracker.FinishedReferences };
-            }, token);
-        }
-        catch (OperationTimeoutException)
-        {
-            warningTracker.Add($"{file.FullName} - scan timed out.");
+            output.Verbose($"{file.FullName} is binary, skipping.", ConsoleColor.Yellow);
             return null;
         }
+
+        output.Verbose($"{file.FullName} - scanning...");
+
+        var lineTracker = new LineTracker(contextLines);
+        var lineNumber = 1;
+
+        var flagSamples = flags.Select(f => new FlagSample
+        {
+            Flag = f,
+            KeySamples = ProduceKeySamples(f).Distinct().ToArray(),
+            Samples = ProduceVariationSamples(f).Distinct().ToArray(),
+            UsagePatterns = usagePatterns
+                .Where(p => p.Contains(Constants.KeyPatternPlaceHolder))
+                .Select(p => new Regex(p.Replace(Constants.KeyPatternPlaceHolder, f.Key), RegexOptions.Compiled))
+                .ToArray()
+        }).ToArray();
+
+        var lines = File.ReadLinesAsync(file.FullName, token);
+        await foreach (var line in lines)
+        {
+            if (line.Length > Constants.MaxCharCountPerLine)
+            {
+                warningTracker.Add(
+                    $"{file.FullName} - {lineNumber}. line is longer than allowed ({Constants.MaxCharCountPerLine} chars), skipping code reference scan.");
+                lineTracker.AddLine("<line was too long>", lineNumber);
+                lineNumber++;
+                continue;
+            }
+
+            foreach (var flagSample in flagSamples)
+            {
+                if (flagSample.KeySamples.Any(k => line.Contains(k)) ||
+                    flagSample.UsagePatterns.Any(p => p.IsMatch(line)))
+                {
+                    lineTracker.TrackReference(flagSample.Flag, line, lineNumber);
+                    continue;
+                }
+
+                if (flagSample.Flag.Aliases.Any(a => line.Contains(a)))
+                {
+                    lineTracker.TrackReference(flagSample.Flag, line, lineNumber, isAlias: true);
+                    continue;
+                }
+
+                foreach (var sample in flagSample.Samples)
+                {
+                    if (line.Contains(sample, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var originalFromLine = line.IndexOf(sample, StringComparison.OrdinalIgnoreCase);
+                        lineTracker.TrackReference(flagSample.Flag, line, lineNumber,
+                            line.Substring(originalFromLine, sample.Length).Remove(Prefixes));
+                    }
+                }
+            }
+
+            lineTracker.AddLine(line, lineNumber);
+            lineNumber++;
+        }
+
+        lineTracker.FinishAll();
+
+        output.Verbose($"{file.FullName} - scan completed.", ConsoleColor.Green);
+        return new FlagReferenceResult { File = file, References = lineTracker.FinishedReferences };
     }
 
     private static IEnumerable<string> ProduceKeySamples(FlagModel flag)
@@ -177,7 +147,8 @@ public class ReferenceCollector : IReferenceCollector
             this.HandleBufferQueue(currentLine);
         }
 
-        public void TrackReference(FlagModel flag, string line, int lineNumber, string matchedSample = null, bool isAlias = false)
+        public void TrackReference(FlagModel flag, string line, int lineNumber, string matchedSample = null,
+            bool isAlias = false)
         {
             var reference = new Reference
             {

--- a/src/ConfigCat.Cli/Commands/Product.cs
+++ b/src/ConfigCat.Cli/Commands/Product.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ConfigCat.Cli.Models.Api;
-using ConfigCat.Cli.Services.Exceptions;
 
 namespace ConfigCat.Cli.Commands;
 

--- a/test/ConfigCat.Cli.Tests/GitClientTests.cs
+++ b/test/ConfigCat.Cli.Tests/GitClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 using ConfigCat.Cli.Models;
 using ConfigCat.Cli.Services.Git;

--- a/test/ConfigCat.Cli.Tests/ScanTests.cs
+++ b/test/ConfigCat.Cli.Tests/ScanTests.cs
@@ -1,6 +1,4 @@
-using System.Collections.Concurrent;
 using ConfigCat.Cli.Models.Api;
-using ConfigCat.Cli.Models.Scan;
 using ConfigCat.Cli.Services.Rendering;
 using ConfigCat.Cli.Services.Scan;
 using Moq;
@@ -8,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Trybot;
 using Xunit;
 
 namespace ConfigCat.Cli.Tests;

--- a/test/ConfigCat.Cli.Tests/ScanTests.cs
+++ b/test/ConfigCat.Cli.Tests/ScanTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using ConfigCat.Cli.Models.Api;
 using ConfigCat.Cli.Models.Scan;
 using ConfigCat.Cli.Services.Rendering;
@@ -17,14 +18,14 @@ public class ScanTests
     [Fact]
     public async Task Alias()
     {
-        var aliasCollector = new AliasCollector(new BotPolicy<AliasScanResult>(), Mock.Of<IOutput>());
+        var aliasCollector = new AliasCollector(Mock.Of<IOutput>());
 
         var flag = new FlagModel { Key = "test_flag" };
         var flag2 = new FlagModel { Key = "leadershipSurvey" };
 
         var result = await aliasCollector.CollectAsync(new[] { flag, flag2 }, new FileInfo("alias.txt"), [], [], CancellationToken.None);
 
-        var aliases = result.FlagAliases.Values.SelectMany(v => v);
+        var aliases = result.Values.SelectMany(v => v).ToList();
 
         Assert.DoesNotContain("feature", aliases);
         Assert.DoesNotContain("notRelevant", aliases);
@@ -71,18 +72,18 @@ public class ScanTests
     [Fact]
     public async Task Scan()
     {
-        var aliasCollector = new AliasCollector(new BotPolicy<AliasScanResult>(), Mock.Of<IOutput>());
-        var scanner = new ReferenceCollector(new BotPolicy<FlagReferenceResult>(), Mock.Of<IOutput>());
+        var aliasCollector = new AliasCollector(Mock.Of<IOutput>());
+        var scanner = new ReferenceCollector(Mock.Of<IOutput>());
 
         var flag = new FlagModel { Key = "test_flag", SettingType = "boolean" };
         var file = new FileInfo("refs.txt");
 
         var result = await aliasCollector.CollectAsync(new[] { flag }, file, [], [], CancellationToken.None);
-        flag.Aliases = result.FlagAliases[flag.Key].ToList();
+        flag.Aliases = result[flag.Key].ToList();
 
         var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
 
-        var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
+        var referenceLines = references.References.Select(r => r.ReferenceLine.LineText).ToList();
 
         Assert.Contains("wrapper.test_flag", referenceLines);
         Assert.Contains("wrapper.testFlag", referenceLines);
@@ -220,19 +221,19 @@ public class ScanTests
     [Fact]
     public async Task Alias_Custom()
     {
-        var aliasCollector = new AliasCollector(new BotPolicy<AliasScanResult>(), Mock.Of<IOutput>());
-        var scanner = new ReferenceCollector(new BotPolicy<FlagReferenceResult>(), Mock.Of<IOutput>());
+        var aliasCollector = new AliasCollector(Mock.Of<IOutput>());
+        var scanner = new ReferenceCollector(Mock.Of<IOutput>());
 
         var flag = new FlagModel { Key = "test_flag", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
         var result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) = :CC_KEY"], [], CancellationToken.None);
-        flag.Aliases = result.FlagAliases[flag.Key].ToList();
+        flag.Aliases = result[flag.Key].ToList();
         
         Assert.Contains("CUS_TEST_FLAG",  flag.Aliases);
 
         var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
-        var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
+        var referenceLines = references.References.Select(r => r.ReferenceLine.LineText).ToList();
 
         Assert.Contains("CUS_TEST_FLAG = :test_flag", referenceLines);
         Assert.Contains("Somewhere else refer to CUS_TEST_FLAG", referenceLines);
@@ -241,41 +242,41 @@ public class ScanTests
     [Fact]
     public async Task Alias_Custom_Other()
     {
-        var aliasCollector = new AliasCollector(new BotPolicy<AliasScanResult>(), Mock.Of<IOutput>());
-        var scanner = new ReferenceCollector(new BotPolicy<FlagReferenceResult>(), Mock.Of<IOutput>());
+        var aliasCollector = new AliasCollector(Mock.Of<IOutput>());
+        var scanner = new ReferenceCollector(Mock.Of<IOutput>());
 
         var flag = new FlagModel { Key = "test_flag", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
         var result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) := FLAGS(CC_KEY)"], [], CancellationToken.None);
-        flag.Aliases = result.FlagAliases[flag.Key].ToList();
+        flag.Aliases = result[flag.Key].ToList();
         
         Assert.Contains("is_test_flag_on",  flag.Aliases);
 
         var references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
-        var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
+        var referenceLines = references.References.Select(r => r.ReferenceLine.LineText).ToList();
 
         Assert.Contains("let is_test_flag_on := FLAGS('test_flag')", referenceLines);
         Assert.Contains("Reference to is_test_flag_on", referenceLines);
         
         result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"(\w+) = client_wrapper\.get_flag\(:CC_KEY\)"], [], CancellationToken.None);
-        flag.Aliases = result.FlagAliases[flag.Key].ToList();
+        flag.Aliases = result[flag.Key].ToList();
         
         Assert.Contains("CUS2_TEST_FLAG",  flag.Aliases);
 
         references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
-        referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
+        referenceLines = references.References.Select(r => r.ReferenceLine.LineText).ToList();
 
         Assert.Contains("CUS2_TEST_FLAG = client_wrapper.get_flag(:test_flag)", referenceLines);
         Assert.Contains("Reference to CUS2_TEST_FLAG", referenceLines);
         
         result = await aliasCollector.CollectAsync(new[] { flag }, file, [@"client_wrapper\.get_flag\(:CC_KEY, (\w+) =>"], [], CancellationToken.None);
-        flag.Aliases = result.FlagAliases[flag.Key].ToList();
+        flag.Aliases = result[flag.Key].ToList();
         
         Assert.Contains("cust_flag_val",  flag.Aliases);
 
         references = await scanner.CollectAsync(new[] { flag }, file, 0, [], [], CancellationToken.None);
-        referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
+        referenceLines = references.References.Select(r => r.ReferenceLine.LineText).ToList();
 
         Assert.Contains("client_wrapper.get_flag(:test_flag, cust_flag_val => {", referenceLines);
         Assert.Contains("Reference to cust_flag_val", referenceLines);
@@ -284,31 +285,31 @@ public class ScanTests
     [Fact]
     public async Task Alias_Patterns_Bad()
     {
-        var aliasCollector = new AliasCollector(new BotPolicy<AliasScanResult>(), Mock.Of<IOutput>());
+        var aliasCollector = new AliasCollector(Mock.Of<IOutput>());
 
         var flag = new FlagModel { Key = "another_flag", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
         var result = await aliasCollector.CollectAsync(new[] { flag }, file, [":CC_KEY"], [], CancellationToken.None);
-        Assert.Empty(result.FlagAliases);
+        Assert.Empty(result);
     }
     
     [Fact]
     public async Task Usage_Custom()
     {
-        var aliasCollector = new AliasCollector(new BotPolicy<AliasScanResult>(), Mock.Of<IOutput>());
-        var scanner = new ReferenceCollector(new BotPolicy<FlagReferenceResult>(), Mock.Of<IOutput>());
+        var aliasCollector = new AliasCollector(Mock.Of<IOutput>());
+        var scanner = new ReferenceCollector(Mock.Of<IOutput>());
 
         var flag = new FlagModel { Key = "test_flag", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
         var result = await aliasCollector.CollectAsync([flag], file, [@"(\w+) = client_wrapper\.get_flag\(:CC_KEY\)"], [], CancellationToken.None);
-        flag.Aliases = result.FlagAliases[flag.Key].ToList();
+        flag.Aliases = result[flag.Key].ToList();
         
         Assert.Contains("is_test_flag_on",  flag.Aliases);
 
         var references = await scanner.CollectAsync(new[] { flag }, file, 0, [@"get_flag\(:CC_KEY"], [], CancellationToken.None);
-        var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);
+        var referenceLines = references.References.Select(r => r.ReferenceLine.LineText).ToList();
 
         Assert.Contains("let is_test_flag_on := FLAGS('test_flag')", referenceLines);
         Assert.Contains("Reference to is_test_flag_on", referenceLines);
@@ -320,14 +321,14 @@ public class ScanTests
     [Fact]
     public async Task Usage_Custom_Direct()
     {
-        var aliasCollector = new AliasCollector(new BotPolicy<AliasScanResult>(), Mock.Of<IOutput>());
-        var scanner = new ReferenceCollector(new BotPolicy<FlagReferenceResult>(), Mock.Of<IOutput>());
+        var aliasCollector = new AliasCollector(Mock.Of<IOutput>());
+        var scanner = new ReferenceCollector(Mock.Of<IOutput>());
 
         var flag = new FlagModel { Key = "test_direct", SettingType = "boolean" };
         var file = new FileInfo("custom.txt");
 
         var result = await aliasCollector.CollectAsync([flag], file, [], [], CancellationToken.None);
-        Assert.Empty(result.FlagAliases);
+        Assert.Empty(result);
 
         var references = await scanner.CollectAsync(new[] { flag }, file, 0, [":CC_KEY"], [], CancellationToken.None);
         var referenceLines = references.References.Select(r => r.ReferenceLine.LineText);


### PR DESCRIPTION
### Describe the purpose of your pull request

Upon scanning, each file reading task had a timeout set (1 min). With too many tasks running parallel, while a task's timeout counter started ticking, its execution remained in a suspended state. Eventually, it was cancelled due to the timeout, even if it was supposed to work on a fairly small file, so nothing really justified the timeout. 

Now, only the whole scanning process has a timeout (30 min), and the /file timeouts were removed.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
