### PR TITLE
Make the scan timeout configurable via argument

### DIFF
--- a/docs/configcat-scan.md
+++ b/docs/configcat-scan.md
@@ -13,6 +13,7 @@ configcat scan ./dir -c <config-id> -l 5 --print
 | ------ | ----------- |
 | `--config-id`, `-c` | ID of the Config to scan against |
 | `--line-count`, `-l` | Context line count before and after the reference line (min: 1, max: 10) |
+| `--timeout`, `-to` | Scan timeout in seconds (default: 1800, min: 60) |
 | `--print`, `-p` | Print found references to output |
 | `--upload`, `-u` | Upload references to ConfigCat |
 | `--repo`, `-r` | Repository name. Mandatory for code reference upload |

--- a/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
+++ b/src/ConfigCat.Cli.Services/Scan/FileScanner.cs
@@ -19,6 +19,7 @@ public interface IFileScanner
         string[] matchPatterns,
         string[] usagePatterns,
         int contextLines,
+        TimeSpan timeout,
         List<string> warningTracker,
         CancellationToken token);
 }
@@ -40,7 +41,6 @@ public class FileScanner : IFileScanner
         this.aliasCollector = aliasCollector;
         this.botPolicy = botPolicy;
         this.output = output;
-        this.botPolicy.Configure(p => p.Timeout(t => t.After(TimeSpan.FromMinutes(30))));
     }
 
     public async Task<IEnumerable<FlagReferenceResult>> ScanAsync(FlagModel[] flags,
@@ -48,9 +48,11 @@ public class FileScanner : IFileScanner
         string[] matchPatterns,
         string[] usagePatterns,
         int contextLines,
+        TimeSpan timeout,
         List<string> warningTracker,
         CancellationToken token)
     {
+        this.botPolicy.Configure(p => p.Timeout(t => t.After(timeout)));
         using var spinner = this.output.CreateSpinner(token);
         return await this.botPolicy.ExecuteAsync(async (_, cancellation) =>
         {

--- a/src/ConfigCat.Cli/CommandBuilder.cs
+++ b/src/ConfigCat.Cli/CommandBuilder.cs
@@ -1293,6 +1293,7 @@ public static class CommandBuilder
             {
                 new Option<string>(["--config-id", "-c"], "ID of the Config to scan against"),
                 new Option<int>(["--line-count", "-l"], () => 4, "Context line count before and after the reference line (min: 1, max: 10)"),
+                new Option<int>(["--timeout", "-to"], () => 1800, "Scan timeout in seconds (default: 1800, min: 60)"),
                 new Option<bool>(["--print", "-p"], "Print found references to output"),
                 new Option<bool>(["--upload", "-u"], "Upload references to ConfigCat"),
                 new Option<string>(["--repo", "-r"], "Repository name. Mandatory for code reference upload"),

--- a/src/ConfigCat.Cli/CommandDescriptor.cs
+++ b/src/ConfigCat.Cli/CommandDescriptor.cs
@@ -16,13 +16,13 @@ public class CommandDescriptor(string name, string description, string example =
 
     public bool IsHidden { get; init; }
 
-    public IEnumerable<Option> Options { get; init; } = Enumerable.Empty<Option>();
+    public IEnumerable<Option> Options { get; init; } = [];
 
-    public IEnumerable<Argument> Arguments { get; init; } = Enumerable.Empty<Argument>();
+    public IEnumerable<Argument> Arguments { get; init; } = [];
 
-    public IEnumerable<string> Aliases { get; init; } = Enumerable.Empty<string>();
+    public IEnumerable<string> Aliases { get; init; } = [];
 
-    public IEnumerable<CommandDescriptor> SubCommands { get; init; } = Enumerable.Empty<CommandDescriptor>();
+    public IEnumerable<CommandDescriptor> SubCommands { get; init; } = [];
 
     public HandlerDescriptor Handler { get; init; }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request
- This PR adds a `--timeout` argument to the `scan` command to make the scan operation's `30m` timeout configurable.

### Related issues (only if applicable)
- #39 

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
